### PR TITLE
Support for NTK-aware Scaled RoPE

### DIFF
--- a/docs/ApiServerArgs.md
+++ b/docs/ApiServerArgs.md
@@ -68,3 +68,10 @@ the max value for one reqest's input token len.
 #### --max_req_total_len
 default is 3072,  
 the max value for req_input_len + req_output_len.
+
+#### --ntk
+This parameter is related to NTK-aware Scaled RoPE, a method to extend the context of LLaMA models without any need for fine-tuning. See the discussion [here](https://www.reddit.com/r/LocalLLaMA/comments/14lz7j5/ntkaware_scaled_rope_allows_llama_models_to_have/)
+
+This argument specifies the alpha value (scaling factor) for NTK-aware Scaled RoPE. If you do not want to use this method, set the value to 1, which is equivalent to not scaling.
+
+Currently only LLaMA2-based models have been tested, argument is ignored for other models.

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -17,11 +17,12 @@ from .stats import Stats
 class RouterManager:
 
     def __init__(self, weightdir, load_way, world_size, max_total_token_num, batch_max_tokens, running_max_req_size, eos_id, 
-                 router_port, detokenization_port, model_rpc_ports, mode="", log_stats=True, log_stats_interval=10):
+                 router_port, detokenization_port, model_rpc_ports, ntk_alpha, mode="", log_stats=True, log_stats_interval=10):
         self.model_weightdir = weightdir
         self.world_size = world_size
         self.load_way = load_way
         self.mode = mode
+        self.ntk_alpha = ntk_alpha
         self.max_total_token_num = max_total_token_num
 
         self.req_queue = ReqQueue(max_total_token_num, batch_max_tokens, running_max_req_size)
@@ -56,6 +57,7 @@ class RouterManager:
                     self.world_size,
                     self.model_weightdir,
                     self.max_total_token_num,
+                    self.ntk_alpha,
                     self.load_way,
                     self.mode))
 
@@ -236,7 +238,7 @@ class RouterManager:
             model_rpc.rpc_server_process.join()
         return
 
-def start_router_process(args, router_port, detokenization_port, model_rpc_ports, mode, pipe_writer):
+def start_router_process(args, router_port, detokenization_port, model_rpc_ports, mode, ntk_alpha, pipe_writer):
     try:
         router = RouterManager(
             args.model_dir,
@@ -250,6 +252,7 @@ def start_router_process(args, router_port, detokenization_port, model_rpc_ports
             detokenization_port=detokenization_port,
             model_rpc_ports=model_rpc_ports,
             mode=mode,
+            ntk_alpha=ntk_alpha,
             log_stats = not args.disable_log_stats,
             log_stats_interval = args.log_stats_interval)
     

--- a/lightllm/server/router/model_infer/model_rpc.py
+++ b/lightllm/server/router/model_infer/model_rpc.py
@@ -20,7 +20,7 @@ from .post_process import sample
 
 class ModelRpcServer(rpyc.Service):
 
-    def exposed_init_model(self, rank_id, world_size, weight_dir, max_total_token_num, load_way, mode):
+    def exposed_init_model(self, rank_id, world_size, weight_dir, max_total_token_num, ntk_alpha, load_way, mode):
         import torch
         import torch.distributed as dist
         if world_size != 1:
@@ -47,7 +47,7 @@ class ModelRpcServer(rpyc.Service):
            if "num_key_value_heads" not in model_cfg.keys():
                self.model = LlamaTpPartModel(rank_id, world_size, weight_dir, max_total_token_num, load_way, mode)
            else:
-               self.model = Llama2TpPartModel(rank_id, world_size, weight_dir, max_total_token_num, load_way, mode)
+               self.model = Llama2TpPartModel(rank_id, world_size, weight_dir, max_total_token_num, ntk_alpha, load_way, mode)
         elif self.model_type == 'gpt_bigcode':
             self.model = StarcoderTpPartModel(rank_id, world_size, weight_dir, max_total_token_num, load_way, mode)
         elif self.model_type == 'qwen':
@@ -181,8 +181,8 @@ class ModelRpcClient:
             self._remove_batch = self.model.exposed_remove_batch
         return
 
-    async def init_model(self, rank_id, world_size, weight_dir, max_total_token_num, load_way, mode):
-        ans : rpyc.AsyncResult = self._init_model(rank_id, world_size, weight_dir, max_total_token_num, load_way, mode)
+    async def init_model(self, rank_id, world_size, weight_dir, max_total_token_num, ntk_alpha, load_way, mode):
+        ans : rpyc.AsyncResult = self._init_model(rank_id, world_size, weight_dir, max_total_token_num, ntk_alpha, load_way, mode)
         if self.use_rpc:
             await ans
             return


### PR DESCRIPTION
This PR adds support for NTK-aware Scaled RoPE, a method to extend the context length of LLaMA models without any need for fine-tuning. See the discussion [here](https://www.reddit.com/r/LocalLLaMA/comments/14lz7j5/ntkaware_scaled_rope_allows_llama_models_to_have/).

A new argument, `--ntk`, has been added to API Server. This argument specifies the alpha value (scaling factor) of NTK-aware Scaled RoPE. It defaults to 1, which is equivalent to not scaling (NTK disabled).

This feature is useful because it allows LLaMA models to have extended (8k+) context size without any fine-tuning and minimal perplexity degradation. The models themselves do not need to be changed.