### PR TITLE
Support for NTK-aware Scaled RoPE from Environment Variables

### DIFF
--- a/lightllm/models/llama/model.py
+++ b/lightllm/models/llama/model.py
@@ -82,7 +82,7 @@ class LlamaTpPartModel(TpPartBaseModel):
             max_seq_len *= ntk_alpha
             base = base * (ntk_alpha ** (self.head_dim_ / (self.head_dim_-2))) #Base change formula
         except:
-            print("Invalid value for LIGHTLLM_NTK_ALPHA, ignoring")
+            pass
 
         inv_freq = 1.0 / (base ** (torch.arange(0, self.head_dim_, 2, device="cpu", dtype=torch.float32) / self.head_dim_))
         t = torch.arange(max_seq_len + 1024 * 64, device="cpu", dtype=torch.float32) / rope_scaling_factor

--- a/lightllm/models/llama/model.py
+++ b/lightllm/models/llama/model.py
@@ -72,6 +72,18 @@ class LlamaTpPartModel(TpPartBaseModel):
         else:
             max_seq_len = self.config.get("max_position_embeddings", 2048) * rope_scaling_factor
         base = float(base)
+
+        # NTK
+        try:
+            ntk_alpha = float(os.environ.get("LIGHTLLM_NTK_ALPHA", 1))
+            assert ntk_alpha >= 1
+            if ntk_alpha > 1:
+                print(f"Note: NTK enabled, alpha set to {ntk_alpha}")
+            max_seq_len *= ntk_alpha
+            base = base * (ntk_alpha ** (self.head_dim_ / (self.head_dim_-2))) #Base change formula
+        except:
+            print("Invalid value for LIGHTLLM_NTK_ALPHA, ignoring")
+
         inv_freq = 1.0 / (base ** (torch.arange(0, self.head_dim_, 2, device="cpu", dtype=torch.float32) / self.head_dim_))
         t = torch.arange(max_seq_len + 1024 * 64, device="cpu", dtype=torch.float32) / rope_scaling_factor
         freqs = torch.outer(t, inv_freq)


### PR DESCRIPTION
This PR reopens #82 , but reads settings from `LIGHTLLM_NTK_ALPHA` environment variable instead of startup argument.