### PR TITLE
support sending input_emds as input for TpPartBaseModel.forward

### DIFF
--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -120,12 +120,12 @@ class TpPartBaseModel:
             b_loc : torch.Tensor,
             b_start_loc : torch.Tensor,
             b_seq_len : torch.Tensor,
-            input_embeds: torch.Tensor = None,
+            input_embs: torch.Tensor = None,
             is_prefill=True):
         if is_prefill:
-            return self._prefill(batch_size, total_token_num, max_len_in_batch, input_ids, b_loc, b_start_loc, b_seq_len, input_embeds)
+            return self._prefill(batch_size, total_token_num, max_len_in_batch, input_ids, b_loc, b_start_loc, b_seq_len, input_embs)
         else:
-            return self._decode(batch_size, total_token_num, max_len_in_batch, input_ids, b_loc, b_start_loc, b_seq_len, input_embeds)
+            return self._decode(batch_size, total_token_num, max_len_in_batch, input_ids, b_loc, b_start_loc, b_seq_len, input_embs)
 
     
     def _prefill(self, batch_size, total_token_num, max_len_in_batch, input_ids, b_loc, b_start_loc, b_seq_len, input_embs=None):

--- a/lightllm/common/basemodel/infer_struct.py
+++ b/lightllm/common/basemodel/infer_struct.py
@@ -36,5 +36,6 @@ class InferStateInfo:
             b_loc : torch.Tensor,
             b_start_loc : torch.Tensor,
             b_seq_len : torch.Tensor,
-            is_prefill):
+            is_prefill,
+            input_embs : torch.Tensor = None):
         pass

--- a/lightllm/models/llama/infer_struct.py
+++ b/lightllm/models/llama/infer_struct.py
@@ -17,7 +17,8 @@ class LlamaInferStateInfo(InferStateInfo):
             b_loc : torch.Tensor,
             b_start_loc : torch.Tensor,
             b_seq_len : torch.Tensor,
-            is_prefill):
+            is_prefill,
+            input_embs : torch.Tensor = None):
         if is_prefill:
             b_seq_len_numpy = b_seq_len.cpu().numpy()
             position_ids = torch.from_numpy(np.concatenate([np.arange(0, b_seq_len_numpy[i])

--- a/lightllm/models/starcoder/layer_infer/infer_struct.py
+++ b/lightllm/models/starcoder/layer_infer/infer_struct.py
@@ -16,7 +16,8 @@ class StarcoderInferStateInfo(InferStateInfo):
             b_loc : torch.Tensor,
             b_start_loc : torch.Tensor,
             b_seq_len : torch.Tensor,
-            is_prefill):
+            is_prefill,
+            input_embs : torch.Tensor = None):
         if is_prefill:
             b_seq_len_numpy = b_seq_len.cpu().numpy()
             self.position_ids = torch.from_numpy(np.concatenate([np.arange(0, b_seq_len_numpy[i])

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ starlette==0.22.0
 sympy==1.12
 tokenizers==0.13.3
 toolz==0.12.0
-torch==1.13.1
+torch==2.0.0
 tqdm==4.65.0
 transformers==4.29.2
 triton==2.0.0.dev20221202

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ starlette==0.22.0
 sympy==1.12
 tokenizers==0.13.3
 toolz==0.12.0
-torch==2.0.0
+torch==1.13.1
 tqdm==4.65.0
 transformers==4.29.2
 triton==2.0.0.dev20221202


### PR DESCRIPTION
Usually the multimodal LLM (Llava, mPLUG-OWL, etc) will encode the text and image together in advance before feeding to LLM. Adding ``input_emds`` argument for ``TpPartBaseModel.forward`` can make lightllm to be applied to these models' inference