### PR TITLE
Add `id` and `logprob` to `generate_stream`

### DIFF
--- a/lightllm/server/api_server.py
+++ b/lightllm/server/api_server.py
@@ -63,7 +63,7 @@ async def generate(request: Request) -> Response:
 
     # Non-streaming case
     final_output = []
-    async for request_output in results_generator:
+    async for request_output, _ in results_generator:
         if await request.is_disconnected():
             # Abort the request if the client disconnects.
             await httpserver_manager.abort(request_id)
@@ -94,11 +94,11 @@ async def generate_stream(request: Request) -> Response:
 
     # Streaming case
     async def stream_results() -> AsyncGenerator[bytes, None]:
-        async for request_output in results_generator:
+        async for request_output, metadata in results_generator:
             ret = {"token":{
                          "id": None, 
                          "text":request_output,
-                         "logprob":None,
+                         "logprob":metadata.get('logprob', None),
                          "special":False},
                          "generated_text":None,
                          "details":None}

--- a/lightllm/server/api_server.py
+++ b/lightllm/server/api_server.py
@@ -96,7 +96,7 @@ async def generate_stream(request: Request) -> Response:
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output, metadata in results_generator:
             ret = {"token":{
-                         "id": None, 
+                         "id": metadata.get('id', None),
                          "text":request_output,
                          "logprob":metadata.get('logprob', None),
                          "special":False},

--- a/lightllm/server/detokenization/manager.py
+++ b/lightllm/server/detokenization/manager.py
@@ -39,18 +39,19 @@ class DeTokenizationManager:
                         
                 if isinstance(recv_obj, BatchTokenIdOut):
                     new_batch_str_out = BatchStrOut()
-                    for req_id, new_token_id, finished, abort in recv_obj.reqs_infs:
+                    for req_id, new_token_id, new_gen_metadata, finished, abort in recv_obj.reqs_infs:
                         if req_id not in self.req_id_to_out:
                             continue
                         req_out:ReqDetokenizationState = self.req_id_to_out[req_id]
                         req_out.output_ids.append(new_token_id)
+                        req_out.gen_metadata.update(new_gen_metadata)
                         out_text = decode_token(self.tokenizer, req_out, new_token_id, skip_special_tokens=True)
                         if out_text.endswith(u'\ufffd'):
                             new_text = ''
                         else:
                             new_text = out_text[len(req_out.output_str):]
                             req_out.output_str = out_text
-                        new_batch_str_out.reqs_infs.append((req_id, new_text, True if abort else finished, abort))
+                        new_batch_str_out.reqs_infs.append((req_id, new_text, new_gen_metadata, True if abort else finished, abort))
                         if finished or abort:
                             try:
                                 del self.req_id_to_out[req_id]

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -44,8 +44,8 @@ class HttpServerManager:
                 pass
             event.clear()
             out_str, metadata, finished, _ = self.req_id_to_out_inf[request_id]
-            if out_str != "":
-                self.req_id_to_out_inf[request_id] = ("", metadata, finished, event)
+            if len(metadata) != 0:
+                self.req_id_to_out_inf[request_id] = ("", {}, finished, event)
                 yield out_str, metadata
             if finished:
                 try:

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -17,7 +17,7 @@ class HttpServerManager:
         
         self.tokenizer = get_tokenizer(model_weightdir, tokenizor_mode, trust_remote_code=trust_remote_code)
         
-        self.req_id_to_out_inf = {}  # value type (out_str, finished, event)
+        self.req_id_to_out_inf = {}  # value type (out_str, metadata, finished, event)
         
         self.total_token_num = total_token_num
         self.max_req_input_len = max_req_input_len
@@ -36,17 +36,17 @@ class HttpServerManager:
         
         self.send_to_router.send_pyobj((prompt_ids, sampling_params, request_id))
         event = asyncio.Event()
-        self.req_id_to_out_inf[request_id] =("", False, event)
+        self.req_id_to_out_inf[request_id] =("", {}, False, event)
         while True:
             try:
                 await asyncio.wait_for(event.wait(), timeout=5)
             except asyncio.TimeoutError:
                 pass
             event.clear()
-            out_str, finished, _ = self.req_id_to_out_inf[request_id]
+            out_str, metadata, finished, _ = self.req_id_to_out_inf[request_id]
             if out_str != "":
-                self.req_id_to_out_inf[request_id] = ("", finished, event)
-                yield out_str
+                self.req_id_to_out_inf[request_id] = ("", metadata, finished, event)
+                yield out_str, metadata
             if finished:
                 try:
                     del self.req_id_to_out_inf[request_id]
@@ -68,14 +68,11 @@ class HttpServerManager:
         while True:
             recv_ans:BatchStrOut = await self.recv_from_detokenization.recv_pyobj()
             assert isinstance(recv_ans, BatchStrOut), f"error recv type {type(recv_ans)}"
-            for req_id, text, finished, abort in recv_ans.reqs_infs:
-                try:
-                    if not abort:
-                        _, _, event = self.req_id_to_out_inf[req_id]
-                        self.req_id_to_out_inf[req_id] = (text, finished, event)
-                        event.set()
-                    else:
-                        del self.req_id_to_out_inf[req_id]
-                except:
-                    pass
+            for req_id, text, metadata, finished, abort in recv_ans.reqs_infs:
+                if not abort:
+                    _, _, _, event = self.req_id_to_out_inf[req_id]
+                    self.req_id_to_out_inf[req_id] = (text, metadata, finished, event)
+                    event.set()
+                else:
+                    self.req_id_to_out_inf.pop(req_id, None)
         return

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -69,10 +69,13 @@ class HttpServerManager:
             recv_ans:BatchStrOut = await self.recv_from_detokenization.recv_pyobj()
             assert isinstance(recv_ans, BatchStrOut), f"error recv type {type(recv_ans)}"
             for req_id, text, metadata, finished, abort in recv_ans.reqs_infs:
-                if not abort:
-                    _, _, _, event = self.req_id_to_out_inf[req_id]
-                    self.req_id_to_out_inf[req_id] = (text, metadata, finished, event)
-                    event.set()
-                else:
-                    self.req_id_to_out_inf.pop(req_id, None)
+                try:
+                    if not abort:
+                        _, _, _, event = self.req_id_to_out_inf[req_id]
+                        self.req_id_to_out_inf[req_id] = (text, metadata, finished, event)
+                        event.set()
+                    else:
+                        del self.req_id_to_out_inf[req_id]
+                except:
+                    pass
         return

--- a/lightllm/server/io_struct.py
+++ b/lightllm/server/io_struct.py
@@ -11,6 +11,7 @@ class Req:
         self.max_output_len = sample_params.max_new_tokens
         self.sample_params = sample_params
         self.output_ids = []
+        self.output_metadata_list = []
         self.has_generate_finished = False
         self.aborted = False
 
@@ -22,6 +23,8 @@ class Req:
 
     def to_req_detokenization_state(self):
         out = ReqDetokenizationState(self.request_id, self.prompt_ids, self.max_output_len, self.sample_params.ignore_eos)
+        if self.output_metadata_list:
+            out.gen_metadata.update(self.output_metadata_list[-1])
         return out
 
     def __repr__(self):
@@ -46,6 +49,7 @@ class ReqDetokenizationState:
         self.current_sub_text = []
         self.max_output_len = max_output_len
         self.ignore_eos = ignore_eos
+        self.gen_metadata = {}
 
 class Batch:
     def __init__(self, batch_id, reqs: List[Req]):
@@ -105,11 +109,11 @@ class Batch:
         
 class BatchTokenIdOut:
     def __init__(self):
-        self.reqs_infs: List[Tuple[str, int, bool, bool]] = []  # [req_id, new_token_id, finished_state, abort_state]
+        self.reqs_infs: List[Tuple[str, int, Dict, bool, bool]] = []  # [req_id, new_token_id, gen_metadata, finished_state, abort_state]
 
 class BatchStrOut:
     def __init__(self):
-        self.reqs_infs: List[Tuple[str, int, bool, bool]] = [] # [req_id, token_str, finished_state, abort_state]
+        self.reqs_infs: List[Tuple[str, str, Dict, bool, bool]] = [] # [req_id, token_str, gen_metadata, finished_state, abort_state]
         
 class AbortReq:
     def __init__(self, req_id):

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -201,16 +201,17 @@ class RouterManager:
             return
     
     def _add_token_id_to_req(self, batch: Batch, req_ans):
-        for req_id, new_token_id in req_ans.items():
+        for req_id, (new_token_id, new_gen_metadata) in req_ans.items():
             req = batch.id_to_reqs[req_id]
             req.output_ids.append(new_token_id)
+            req.output_metadata_list.append(new_gen_metadata)
         return
         
     def _send_to_detokenization_proc(self, batch: Batch, req_ans):
         batch_out = BatchTokenIdOut()
-        for req_id, new_token_id in req_ans.items():
+        for req_id, (new_token_id, new_gen_metadata) in req_ans.items():
             req = batch.id_to_reqs[req_id]
-            batch_out.reqs_infs.append((req_id, new_token_id, req.has_generate_finished, req.aborted))
+            batch_out.reqs_infs.append((req_id, new_token_id, new_gen_metadata, req.has_generate_finished, req.aborted))
     
         self.send_to_detokenization.send_pyobj(batch_out)
         return

--- a/lightllm/server/router/model_infer/model_rpc.py
+++ b/lightllm/server/router/model_infer/model_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import rpyc
 import torch
 import traceback
@@ -144,11 +145,12 @@ class ModelRpcServer(rpyc.Service):
         # assert False, f"{kwargs}"
 
         logits = self.model.forward(**kwargs)
-        next_token_ids = sample(logits, batch)
+        next_token_ids, next_token_probs = sample(logits, batch)
+        next_token_logprobs = torch.log(next_token_probs)
         output_dict = {}
         new_input_ids = []        
         next_token_ids = next_token_ids.detach().cpu().numpy()
-        for i, (r, all_input_ids, next_token_id) in enumerate(zip(batch.requests, batch.all_input_ids, next_token_ids)):
+        for i, (r, all_input_ids, next_token_id, next_token_logprob) in enumerate(zip(batch.requests, batch.all_input_ids, next_token_ids, next_token_logprobs)):
             # all_input_ids_tensor = torch.tensor(all_input_ids, dtype=torch.long, device="cuda")
             all_input_ids.append(int(next_token_id))
             # all_input_ids_tensor = None
@@ -156,7 +158,10 @@ class ModelRpcServer(rpyc.Service):
             batch.all_input_ids[i] = all_input_ids
             batch.input_lengths[i] += 1
             batch.out_token_id_counts[i][next_token_id] += 1
-            output_dict[r['request_id']] = int(next_token_id)
+
+            metadata = {'logprob': float(next_token_logprob)}
+
+            output_dict[r['request_id']] = (int(next_token_id), metadata)
         
         batch.input_ids = torch.tensor(new_input_ids, dtype=torch.long).cuda()
         batch.nopad_b_start_loc = batch.nopad_b_start_loc + torch.arange(0, len(batch), dtype=torch.int32, device="cuda")

--- a/lightllm/server/router/model_infer/model_rpc.py
+++ b/lightllm/server/router/model_infer/model_rpc.py
@@ -147,8 +147,7 @@ class ModelRpcServer(rpyc.Service):
         logits = self.model.forward(**kwargs)
         next_token_ids, next_token_probs = sample(logits, batch)
         next_token_ids = next_token_ids.detach().cpu().numpy()
-        next_token_probs = next_token_probs.detach().cpu().numpy()
-        next_token_logprobs = numpy.log(next_token_probs)
+        next_token_logprobs = torch.log(next_token_probs).detach().cpu().numpy()
         output_dict = {}
         new_input_ids = []        
         for i, (r, all_input_ids, next_token_id, next_token_logprob) in enumerate(zip(batch.requests, batch.all_input_ids, next_token_ids, next_token_logprobs)):

--- a/lightllm/server/router/model_infer/model_rpc.py
+++ b/lightllm/server/router/model_infer/model_rpc.py
@@ -146,7 +146,7 @@ class ModelRpcServer(rpyc.Service):
 
         logits = self.model.forward(**kwargs)
         next_token_ids, next_token_probs = sample(logits, batch)
-        next_token_logprobs = torch.log(next_token_probs)
+        next_token_logprobs = torch.log(next_token_probs.cpu())
         output_dict = {}
         new_input_ids = []        
         next_token_ids = next_token_ids.detach().cpu().numpy()

--- a/lightllm/server/router/model_infer/post_process.py
+++ b/lightllm/server/router/model_infer/post_process.py
@@ -15,8 +15,9 @@ def sample(logits, batch:InferBatch):
     sampled_index = torch.multinomial(probs_sort, num_samples=1, replacement=True)
     
     batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index)
+    batch_next_token_probs = torch.gather(probs_sort, dim=1, index=sampled_index)
     
-    return batch_next_token_ids.view(-1)
+    return batch_next_token_ids.view(-1), batch_next_token_probs.view(-1)
 
 def _top_p_top_k(probs: torch.Tensor, top_ps: torch.Tensor, top_ks: torch.Tensor):    
     probs_sort, probs_idx = probs.sort(dim=-1, descending=True)


### PR DESCRIPTION
Replace dummy `id` and `logprob` to real `id` and `logprob` in `generate_stream` when generating new tokens.