### PR TITLE
Return meaningful finish reason instead of a boolean

### DIFF
--- a/lightllm/server/api_server.py
+++ b/lightllm/server/api_server.py
@@ -164,7 +164,7 @@ async def generate_stream(request: Request) -> Response:
 
     # Streaming case
     async def stream_results() -> AsyncGenerator[bytes, None]:
-        async for request_output, metadata, finished in results_generator:
+        async for request_output, metadata, finish_reason in results_generator:
             ret = {
                 "token": {
                     "id": metadata.get("id", None),
@@ -173,7 +173,7 @@ async def generate_stream(request: Request) -> Response:
                     "special": False
                 },
                 "generated_text": None,
-                "finished": finished,
+                "finish_reason": finish_reason,
                 "details": None
             }
 

--- a/lightllm/server/detokenization/manager.py
+++ b/lightllm/server/detokenization/manager.py
@@ -53,7 +53,7 @@ class DeTokenizationManager:
 
                 if isinstance(recv_obj, BatchTokenIdOut):
                     new_batch_str_out = BatchStrOut()
-                    for req_id, new_token_id, new_gen_metadata, finished, abort in recv_obj.reqs_infs:
+                    for req_id, new_token_id, new_gen_metadata, finish_reason in recv_obj.reqs_infs:
                         if req_id not in self.req_id_to_out:
                             continue
                         req_out:ReqDetokenizationState = self.req_id_to_out[req_id]
@@ -73,8 +73,8 @@ class DeTokenizationManager:
                         else:
                             new_text = out_text[len(req_out.output_str):]
                             req_out.output_str = out_text
-                        new_batch_str_out.reqs_infs.append((req_id, new_text, new_gen_metadata, True if abort else finished, abort))
-                        if finished or abort:
+                        new_batch_str_out.reqs_infs.append((req_id, new_text, new_gen_metadata, finish_reason))
+                        if finish_reason is not None:
                             try:
                                 del self.req_id_to_out[req_id]
                             except:

--- a/lightllm/server/io_struct.py
+++ b/lightllm/server/io_struct.py
@@ -1,6 +1,6 @@
 from .sampling_params import SamplingParams
 from .multimodal_params import MultimodalParams
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 import asyncio
 import enum
 
@@ -12,6 +12,27 @@ class ReqRunStatus(enum.Enum):
     RERUNNING_FROM_KVKEEP = 4 # 从暂停中恢复
     RERUNNING_FROM_OFFLOAD = 5 # 从卸载KV中恢复
 
+class FinishStatus(enum.Enum):
+    NO_FINISH = 0 # 没有结束
+    FINISHED_STOP = 1 # 因为遇到了STOP token 而结束
+    FINISHED_LENGTH = 2 # 因为长度达到了最大长度而结束
+    FINISHED_ABORT = 2 # 因为请求被中止而结束
+
+    @staticmethod
+    def is_finished(status: "FinishStatus"):
+        return status in [FinishStatus.FINISHED_STOP, FinishStatus.FINISHED_LENGTH, FinishStatus.FINISHED_ABORT]
+
+    @staticmethod
+    def get_finish_reason(status: "FinishStatus"):
+        if status == FinishStatus.FINISHED_STOP:
+            finish_reason = "stop"
+        elif status == FinishStatus.FINISHED_LENGTH:
+            finish_reason = "length"
+        elif status == FinishStatus.FINISHED_ABORT:
+            finish_reason = "abort"
+        else:
+            finish_reason = None
+        return finish_reason
 
 class Req:
     def __init__(self, request_id, prompt_ids, sample_params: SamplingParams, multimodal_params: MultimodalParams, prompt_cache_len=0, prompt_cache_req_id=None):
@@ -23,10 +44,9 @@ class Req:
         self.multimodal_params = multimodal_params
         self.output_ids = []
         self.output_metadata_list = []
-        self.has_generate_finished = False
-        self.aborted = False
 
         self.req_status = ReqRunStatus.WAIT_IN_QUEUE
+        self.finish_status = FinishStatus.NO_FINISH
         self.cur_kv_len = 0 # 当前已经占用掉 token 的 kv len 长度
         self.prompt_cache_len = prompt_cache_len # 可以复用的一些公共 prompt 头对应的 kv cache 长度, 只有 splitfuse 模式当前才实际使用
         self.prompt_cache_req_id = prompt_cache_req_id # 对应的可复用的请求的 id，方便初始化的时候，将其 kv cache 复制到当前请求中, 默认值 为 None
@@ -215,13 +235,13 @@ class Batch:
         unfinished_req_ids, finished_req_ids = [], []
         for req in self.reqs:
             if req.stop_sequences_matched():
-                req.has_generate_finished = True
-            if len(req.output_ids) >= 1 and req.output_ids[-1] == eos_id and req.sample_params.ignore_eos == False:
-                req.has_generate_finished = True
-            if len(req.output_ids) >= req.max_output_len or req.aborted:
-                req.has_generate_finished = True
+                req.finish_status = FinishStatus.FINISHED_STOP
+            elif len(req.output_ids) >= 1 and req.output_ids[-1] == eos_id and req.sample_params.ignore_eos is False:
+                req.finish_status = FinishStatus.FINISHED_STOP
+            elif len(req.output_ids) >= req.max_output_len:
+                req.finish_status = FinishStatus.FINISHED_LENGTH
 
-            if req.has_generate_finished:
+            if FinishStatus.is_finished(req.finish_status):
                 finished_req_ids.append(req.request_id)
                 # 标记的时候，也同时更新一些这些请求被移除掉的更新量，有点dirty
                 self.batch_used_tokens -= req.get_used_tokens()
@@ -263,11 +283,11 @@ class Batch:
         
 class BatchTokenIdOut:
     def __init__(self):
-        self.reqs_infs: List[Tuple[str, int, Dict, bool, bool]] = []  # [req_id, new_token_id, gen_metadata, finished_state, abort_state]
+        self.reqs_infs: List[Tuple[str, int, Dict, Union[str, None]]] = []  # [req_id, new_token_id, gen_metadata, finish_reason]
 
 class BatchStrOut:
     def __init__(self):
-        self.reqs_infs: List[Tuple[str, str, Dict, bool, bool]] = [] # [req_id, token_str, gen_metadata, finished_state, abort_state]
+        self.reqs_infs: List[Tuple[str, str, Dict, Union[str, None]]] = [] # [req_id, token_str, gen_metadata, finish_reason]
         
 class AbortReq:
     def __init__(self, req_id):

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -13,7 +13,7 @@ from .model_infer.model_rpc import start_model_process, ModelRpcClient
 from .req_queue import ReqQueue
 from rpyc.utils.classic import obtain
 from lightllm.utils.infer_utils import calculate_time
-from ..io_struct import BatchTokenIdOut, AbortReq, ReqRunStatus
+from ..io_struct import BatchTokenIdOut, AbortReq, ReqRunStatus, FinishStatus
 from .stats import Stats
 from .pause_strategy import Fcfs, select_paused_reqs
 from ..tokenizer import get_tokenizer
@@ -133,12 +133,10 @@ class RouterManager:
         if self.running_batch is not None:
             for req in self.running_batch.reqs:
                 if req.request_id == request_id:
-                    req.has_generate_finished = True
-                    req.aborted = True
+                    req.finish_status = FinishStatus.FINISHED_ABORT
         for req in self.req_queue.waiting_req_list:
             if req.request_id == request_id:
-                req.has_generate_finished = True
-                req.aborted = True
+                req.finish_status = FinishStatus.FINISHED_ABORT
         return
 
     async def loop_for_fwd(self,):
@@ -343,7 +341,7 @@ class RouterManager:
         for req_id, (_, _, new_token_id, new_gen_metadata) in req_ans.items():
             req = batch.id_to_reqs[req_id]
             if new_token_id is not None:
-                batch_out.reqs_infs.append((req_id, new_token_id, new_gen_metadata, req.has_generate_finished, req.aborted))
+                batch_out.reqs_infs.append((req_id, new_token_id, new_gen_metadata, FinishStatus.get_finish_reason(req.finish_status)))
     
         self.send_to_detokenization.send_pyobj(batch_out)
         return

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -341,7 +341,8 @@ class RouterManager:
         for req_id, (_, _, new_token_id, new_gen_metadata) in req_ans.items():
             req = batch.id_to_reqs[req_id]
             if new_token_id is not None:
-                batch_out.reqs_infs.append((req_id, new_token_id, new_gen_metadata, FinishStatus.get_finish_reason(req.finish_status)))
+                # req.finish_status 传输 value值 不传送对象，可以减少序列化对象的大小。
+                batch_out.reqs_infs.append((req_id, new_token_id, new_gen_metadata, req.finish_status.value))
     
         self.send_to_detokenization.send_pyobj(batch_out)
         return

--- a/lightllm/server/router/req_queue.py
+++ b/lightllm/server/router/req_queue.py
@@ -5,7 +5,7 @@ from typing import List
 from ..io_struct import Batch, Req
 from lightllm.utils.infer_utils import calculate_time
 from lightllm.server.io_struct import Req
-from lightllm.server.io_struct import ReqRunStatus
+from lightllm.server.io_struct import ReqRunStatus, FinishStatus
 
 class ReqQueue:
 
@@ -103,7 +103,7 @@ class ReqQueue:
         new_batch_first_router_need_tokens = 0 # 主要是对 prefill 或者 splitfuse 大块计算时候的限制
         aborted_count = 0
         for req in self.waiting_req_list:
-            if req.aborted and req.req_status == ReqRunStatus.WAIT_IN_QUEUE: 
+            if req.finish_status == FinishStatus.FINISHED_ABORT and req.req_status == ReqRunStatus.WAIT_IN_QUEUE: 
                 # 由于管理的复杂性，只有没有被调度运行过的请求可以因为abort直接在队列中忽略掉. 
                 # 暂停的请求需要恢复后，由 router manager 部分来过滤。暂时保持这种处理方法, 否则会导致管理token的泄漏
                 aborted_count += 1

--- a/lightllm/server/router/req_queue.py
+++ b/lightllm/server/router/req_queue.py
@@ -103,7 +103,7 @@ class ReqQueue:
         new_batch_first_router_need_tokens = 0 # 主要是对 prefill 或者 splitfuse 大块计算时候的限制
         aborted_count = 0
         for req in self.waiting_req_list:
-            if req.finish_status == FinishStatus.FINISHED_ABORT and req.req_status == ReqRunStatus.WAIT_IN_QUEUE: 
+            if req.finish_status.is_aborted() and req.req_status == ReqRunStatus.WAIT_IN_QUEUE: 
                 # 由于管理的复杂性，只有没有被调度运行过的请求可以因为abort直接在队列中忽略掉. 
                 # 暂停的请求需要恢复后，由 router manager 部分来过滤。暂时保持这种处理方法, 否则会导致管理token的泄漏
                 aborted_count += 1


### PR DESCRIPTION
Return a string to describe about the finish reason.

Related to https://github.com/ModelTC/lightllm/issues/130

Due to in codebase there exists the usage like

```
req.aborted and req.req_status == ReqRunStatus.WAIT_IN_QUEUE
```

It is not suitable to merge `ReqRunStatus` and `FinishStatus`, so I separate an individual class to indicate the finish reason.