### PR TITLE
[misc] modify flash decoding function

### DIFF
--- a/lightllm/models/llama/layer_infer/transformer_layer_infer.py
+++ b/lightllm/models/llama/layer_infer/transformer_layer_infer.py
@@ -412,7 +412,14 @@ class LlamaTransformerLayerInfer(TransformerLayerInferTpl):
             :, self.tp_k_head_num_ : self.tp_k_head_num_ + self.tp_v_head_num_, :
         ]
         return token_decode_attention_flash_decoding(
-            q, infer_state, self.tp_q_head_num_, self.head_dim_, cache_k, cache_v, out=out
+            q,
+            infer_state,
+            self.tp_q_head_num_,
+            self.head_dim_,
+            cache_k,
+            cache_v,
+            out=out,
+            alloc_tensor_func=self.alloc_tensor,
         )
 
     def _token_decode_attention_gqa_flashdecoding(self, q, infer_state: LlamaInferStateInfo, layer_weight, out=None):
@@ -424,7 +431,14 @@ class LlamaTransformerLayerInfer(TransformerLayerInferTpl):
             :, self.tp_k_head_num_ : self.tp_k_head_num_ + self.tp_v_head_num_, :
         ]
         return gqa_token_decode_attention_flash_decoding(
-            q, infer_state, self.tp_q_head_num_, self.head_dim_, cache_k, cache_v, out=out
+            q,
+            infer_state,
+            self.tp_q_head_num_,
+            self.head_dim_,
+            cache_k,
+            cache_v,
+            out=out,
+            alloc_tensor_func=self.alloc_tensor,
         )
 
     def _token_decode_attention_ppl_int8kv(self, q, infer_state: LlamaInferStateInfo, layer_weight, out=None):

--- a/lightllm/models/llama/triton_kernel/flash_decoding.py
+++ b/lightllm/models/llama/triton_kernel/flash_decoding.py
@@ -1,6 +1,9 @@
 import torch
 
-def token_decode_attention_flash_decoding(q, infer_state, q_head_num, head_dim, cache_k, cache_v, out=None):
+
+def token_decode_attention_flash_decoding(
+    q, infer_state, q_head_num, head_dim, cache_k, cache_v, out=None, alloc_tensor_func=torch.empty
+):
     BLOCK_SEQ = 256
     batch_size = infer_state.batch_size
     max_len_in_batch = infer_state.max_len_in_batch
@@ -9,37 +12,30 @@ def token_decode_attention_flash_decoding(q, infer_state, q_head_num, head_dim, 
     from .flash_decoding_stage1 import flash_decode_stage1
     from .flash_decoding_stage2 import flash_decode_stage2
 
-    o_tensor = torch.empty_like(q) if out is None else out
-    
-    if getattr(infer_state, 'mid_o', None) is None:
-        infer_state.mid_o = torch.empty([batch_size, 
-                                        q_head_num, 
-                                        max_len_in_batch // BLOCK_SEQ + 1, 
-                                        head_dim], 
-                                        dtype=torch.float32, 
-                                        device="cuda")
-        infer_state.mid_o_logexpsum = torch.empty([batch_size, 
-                                        q_head_num,
-                                        max_len_in_batch // BLOCK_SEQ + 1], 
-                                        dtype=torch.float32, 
-                                        device="cuda")
-        
+    o_tensor = alloc_tensor_func(q.shape, q.dtype, q.device) if out is None else out
+
+    if getattr(infer_state, "mid_o", None) is None:
+        infer_state.mid_o = alloc_tensor_func(
+            [batch_size, q_head_num, max_len_in_batch // BLOCK_SEQ + 1, head_dim], dtype=torch.float32, device="cuda"
+        )
+        infer_state.mid_o_logexpsum = alloc_tensor_func(
+            [batch_size, q_head_num, max_len_in_batch // BLOCK_SEQ + 1], dtype=torch.float32, device="cuda"
+        )
+
     mid_o = infer_state.mid_o
     mid_o_logexpsum = infer_state.mid_o_logexpsum
 
-    flash_decode_stage1(q.view(calcu_shape1),
-                                cache_k,
-                                cache_v,
-                                infer_state.req_manager.req_to_token_indexs,
-                                infer_state.b_req_idx,
-                                infer_state.b_seq_len,
-                                infer_state.max_len_in_batch,
-                                mid_o,
-                                mid_o_logexpsum,
-                                BLOCK_SEQ)
-    flash_decode_stage2(mid_o,
-                        mid_o_logexpsum, 
-                        infer_state.b_seq_len, 
-                        o_tensor.view(calcu_shape1), 
-                        BLOCK_SEQ)
+    flash_decode_stage1(
+        q.view(calcu_shape1),
+        cache_k,
+        cache_v,
+        infer_state.req_manager.req_to_token_indexs,
+        infer_state.b_req_idx,
+        infer_state.b_seq_len,
+        infer_state.max_len_in_batch,
+        mid_o,
+        mid_o_logexpsum,
+        BLOCK_SEQ,
+    )
+    flash_decode_stage2(mid_o, mid_o_logexpsum, infer_state.b_seq_len, o_tensor.view(calcu_shape1), BLOCK_SEQ)
     return o_tensor

--- a/lightllm/models/llama/triton_kernel/gqa_flash_decoding.py
+++ b/lightllm/models/llama/triton_kernel/gqa_flash_decoding.py
@@ -1,7 +1,9 @@
 import torch
 
 
-def gqa_token_decode_attention_flash_decoding(q, infer_state, q_head_num, head_dim, cache_k, cache_v, out=None):
+def gqa_token_decode_attention_flash_decoding(
+    q, infer_state, q_head_num, head_dim, cache_k, cache_v, out=None, alloc_tensor_func=torch.empty
+):
     BLOCK_SEQ = 128
     batch_size = infer_state.batch_size
     max_len_in_batch = infer_state.max_len_in_batch
@@ -10,13 +12,13 @@ def gqa_token_decode_attention_flash_decoding(q, infer_state, q_head_num, head_d
     from .gqa_flash_decoding_stage1 import flash_decode_stage1
     from .gqa_flash_decoding_stage2 import flash_decode_stage2
 
-    o_tensor = torch.empty_like(q) if out is None else out
+    o_tensor = alloc_tensor_func(q.shape, q.dtype, q.device) if out is None else out
 
     if getattr(infer_state, "mid_o", None) is None:
-        infer_state.mid_o = torch.empty(
+        infer_state.mid_o = alloc_tensor_func(
             [batch_size, q_head_num, max_len_in_batch // BLOCK_SEQ + 1, head_dim], dtype=torch.float32, device="cuda"
         )
-        infer_state.mid_o_logexpsum = torch.empty(
+        infer_state.mid_o_logexpsum = alloc_tensor_func(
             [batch_size, q_head_num, max_len_in_batch // BLOCK_SEQ + 1], dtype=torch.float32, device="cuda"
         )
 


### PR DESCRIPTION
为了实现triton_gqa_flashdecding 算子使用的两个中间tensor，改为外部传入，更好的配合 cache manager的特性的使用。

但是中间两个tensor的大小受BLOCK_SEQ影响，所以在外部申请好tensor再传进来其实比较麻烦。
所以选择直接将申请内存的函数地址作为参数传入。