### PR TITLE
Add fake balance for EP mode

### DIFF
--- a/lightllm/common/fused_moe/topk_select.py
+++ b/lightllm/common/fused_moe/topk_select.py
@@ -21,6 +21,7 @@ import os
 import torch
 from lightllm.utils.sgl_utils import sgl_ops
 from lightllm.utils.light_utils import light_ops
+from lightllm.utils.envs_utils import get_env_start_args
 from lightllm.utils.balance_utils import BalancedTensor
 from typing import Callable, List, Optional, Tuple
 from lightllm.common.fused_moe.softmax_topk import softmax_topk
@@ -228,11 +229,11 @@ def select_experts(
             hidden_states=hidden_states, gating_output=router_logits, topk=top_k, renormalize=renormalize
         )
 
-    # EP fake负载平衡开关
-    if os.environ.get("EP_FAKE_BALANCE_ENABLED") == "true":
-        M, _ = hidden_states.shape
-        balanced_tensor_collection = BalancedTensor()
-        balance_topk_ids = balanced_tensor_collection.get_balance_topk_ids(M)
+    # Enable EP fake balance
+    if get_env_start_args().enable_ep_fake_balance:
+        num_tokens, num_experts = router_logits.shape
+        balanced_tensor_collection = BalancedTensor(num_experts=num_experts, num_selected=top_k)
+        balance_topk_ids = balanced_tensor_collection.get_balance_topk_ids(num_tokens)
         topk_ids.copy_(balance_topk_ids)
 
     return topk_weights, topk_ids

--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -333,6 +333,9 @@ def make_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--enable_monitor_auth", action="store_true", help="Whether to open authentication for push_gateway"
     )
+
+    parser.add_argument("--enable_ep_fake_balance", action="store_true", help="Enable the fake balance of the EP mode")
+
     parser.add_argument("--disable_cudagraph", action="store_true", help="Disable the cudagraph of the decoding stage")
 
     parser.add_argument(

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -76,6 +76,7 @@ class StartArgs:
     visual_dp: int = field(default=1)
     visual_nccl_ports: List[int] = field(default_factory=lambda: [29500])
     enable_monitor_auth: bool = field(default=False)
+    enable_ep_fake_balance: bool = field(default=False)
     disable_cudagraph: bool = field(default=False)
     graph_max_batch_size: int = field(default=256)
     graph_split_batch_size: int = field(default=32)

--- a/lightllm/utils/balance_utils.py
+++ b/lightllm/utils/balance_utils.py
@@ -1,0 +1,63 @@
+import torch
+import os
+
+import threading
+
+def singleton_threadsafe(cls):
+    instances = {}
+    lock = threading.Lock()
+
+    def get_instance(*args, **kwargs):
+        with lock:
+            if cls not in instances:
+                instances[cls] = cls(*args, **kwargs)
+            return instances[cls]
+    return get_instance
+
+@singleton_threadsafe
+class BalancedTensor:
+    def __init__(self, num_experts=256, num_selected=8):
+        self.balanced_tensors = {}
+        self.num_experts = num_experts
+        self.num_selected = num_selected
+
+    def generate_balanced_tensor(self, length):
+        # 初始化一个 length * 8 的全零张量，放置在 GPU 上
+        tensor = torch.zeros((length, self.num_selected), dtype=torch.int, device='cuda')
+        # 初始化每个专家的负载计数
+        expert_load = torch.zeros(self.num_experts, dtype=torch.int, device='cuda')
+
+        for i in range(length):
+            available_experts = torch.arange(self.num_experts, device='cuda')
+            selected = []
+            for _ in range(self.num_selected):
+                # 计算每个可用专家的当前负载
+                current_load = expert_load[available_experts]
+                # 选择负载最小的专家
+                min_load_indices = torch.where(current_load == current_load.min())[0]
+                if len(min_load_indices) > 1:
+                    # 如果有多个负载最小的专家，随机选择一个
+                    chosen_index = torch.randint(0, len(min_load_indices), (1,), device='cuda').item()
+                    chosen_expert_index = min_load_indices[chosen_index]
+                else:
+                    chosen_expert_index = min_load_indices[0]
+                chosen_expert = available_experts[chosen_expert_index]
+                selected.append(chosen_expert)
+                # 从可用专家列表中移除已选择的专家
+                available_experts = torch.cat(
+                    [available_experts[:chosen_expert_index], available_experts[chosen_expert_index + 1:]])
+                # 更新该专家的负载
+                expert_load[chosen_expert] += 1
+            tensor[i] = torch.tensor(selected, dtype=torch.int, device='cuda')
+        return tensor
+
+    def get_balance_topk_ids(self, length):
+        if self.balanced_tensors.get(length) is not None:
+            #print("find length ", length)
+            return self.balanced_tensors[length]
+        else:
+            #print("generate length ", length)
+            tensor = self.generate_balanced_tensor(length)
+            self.balanced_tensors[length] = tensor
+            return tensor
+

--- a/lightllm/utils/balance_utils.py
+++ b/lightllm/utils/balance_utils.py
@@ -3,16 +3,26 @@ import os
 
 import threading
 
+from lightllm.utils.log_utils import init_logger
+
+logger = init_logger(__name__)
+
+
 def singleton_threadsafe(cls):
     instances = {}
     lock = threading.Lock()
 
     def get_instance(*args, **kwargs):
+        # A key that includes the arguments is needed for parameter-dependent singletons.
+        # Using a tuple of args and a frozenset of kwargs items makes it hashable.
+        key = (cls, args, frozenset(kwargs.items()))
         with lock:
-            if cls not in instances:
-                instances[cls] = cls(*args, **kwargs)
-            return instances[cls]
+            if key not in instances:
+                instances[key] = cls(*args, **kwargs)
+            return instances[key]
+
     return get_instance
+
 
 @singleton_threadsafe
 class BalancedTensor:
@@ -21,43 +31,41 @@ class BalancedTensor:
         self.num_experts = num_experts
         self.num_selected = num_selected
 
-    def generate_balanced_tensor(self, length):
-        # 初始化一个 length * 8 的全零张量，放置在 GPU 上
-        tensor = torch.zeros((length, self.num_selected), dtype=torch.int, device='cuda')
-        # 初始化每个专家的负载计数
-        expert_load = torch.zeros(self.num_experts, dtype=torch.int, device='cuda')
+    def generate_balanced_tensor(self, num_tokens):
+        # Evenly distribute num_tokens to num_selected experts out of num_experts.
+        # Note that the num_selected experts activated by a token cannot be repeated.
+        # Performance is not that important, as it is only activated in special scenarios.
+        tensor = torch.zeros((num_tokens, self.num_selected), dtype=torch.int, device="cuda")
+        expert_load = torch.zeros(self.num_experts, dtype=torch.int, device="cuda")
 
-        for i in range(length):
-            available_experts = torch.arange(self.num_experts, device='cuda')
+        for i in range(num_tokens):
+            available_experts = torch.arange(self.num_experts, device="cuda")
             selected = []
             for _ in range(self.num_selected):
-                # 计算每个可用专家的当前负载
                 current_load = expert_load[available_experts]
-                # 选择负载最小的专家
                 min_load_indices = torch.where(current_load == current_load.min())[0]
                 if len(min_load_indices) > 1:
-                    # 如果有多个负载最小的专家，随机选择一个
-                    chosen_index = torch.randint(0, len(min_load_indices), (1,), device='cuda').item()
+                    # If there are multiple least-loaded experts, select one randomly
+                    chosen_index = torch.randint(0, len(min_load_indices), (1,), device="cuda").item()
                     chosen_expert_index = min_load_indices[chosen_index]
                 else:
                     chosen_expert_index = min_load_indices[0]
                 chosen_expert = available_experts[chosen_expert_index]
                 selected.append(chosen_expert)
-                # 从可用专家列表中移除已选择的专家
+                # Remove the selected expert from the list of available experts
                 available_experts = torch.cat(
-                    [available_experts[:chosen_expert_index], available_experts[chosen_expert_index + 1:]])
-                # 更新该专家的负载
+                    [available_experts[:chosen_expert_index], available_experts[chosen_expert_index + 1 :]]
+                )
                 expert_load[chosen_expert] += 1
-            tensor[i] = torch.tensor(selected, dtype=torch.int, device='cuda')
+
+            tensor[i] = torch.tensor(selected, dtype=torch.int, device="cuda")
+
         return tensor
 
-    def get_balance_topk_ids(self, length):
-        if self.balanced_tensors.get(length) is not None:
-            #print("find length ", length)
-            return self.balanced_tensors[length]
-        else:
-            #print("generate length ", length)
-            tensor = self.generate_balanced_tensor(length)
-            self.balanced_tensors[length] = tensor
-            return tensor
+    def get_balance_topk_ids(self, num_tokens):
+        if num_tokens in self.balanced_tensors:
+            return self.balanced_tensors[num_tokens]
 
+        tensor = self.generate_balanced_tensor(num_tokens)
+        self.balanced_tensors[num_tokens] = tensor
+        return tensor


### PR DESCRIPTION
Add fake balance for EP mode, which is controled by option of --enable_ep_fake_balance.
Cost: EP8 batch128 input64 (40+ different seqlens) totally cost about 5 seconds.
Benefit: prefill throughput increase 35%, decoding throughput increase 15%, and the overheads become stable.