### PR TITLE
Add top_logprobs Support

### DIFF
--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -288,7 +288,13 @@ class ModeBackend:
             self.logger.info(f"loaded mtp model class {self.draft_models[i].__class__}")
         return
 
-    def _async_copy_next_token_infos_to_pin_mem(self, next_token_ids: torch.Tensor, next_token_logprobs: torch.Tensor):
+    def _async_copy_next_token_infos_to_pin_mem(
+        self,
+        next_token_ids: torch.Tensor,
+        next_token_logprobs: torch.Tensor,
+        top_k_ids: torch.Tensor = None,
+        top_k_logprobs: torch.Tensor = None,
+    ):
         """
         这个函数会把next token id和logprobs保存到pinned memory中
         这样可以保障post_handle 函数可以读取到正常的输出结果。
@@ -301,7 +307,20 @@ class ModeBackend:
             key="next_token_logprobs",
             gpu_tensor=next_token_logprobs,
         )
-        return next_token_ids_cpu, next_token_logprobs_cpu
+
+        top_k_ids_cpu = None
+        top_k_logprobs_cpu = None
+        if top_k_ids is not None:
+            top_k_ids_cpu = g_pin_mem_manager.async_copy_from_gpu_tensor(
+                key="top_k_ids",
+                gpu_tensor=top_k_ids,
+            )
+            top_k_logprobs_cpu = g_pin_mem_manager.async_copy_from_gpu_tensor(
+                key="top_k_logprobs",
+                gpu_tensor=top_k_logprobs,
+            )
+
+        return next_token_ids_cpu, next_token_logprobs_cpu, top_k_ids_cpu, top_k_logprobs_cpu
 
     def _try_read_new_reqs(self):
         if self.is_multinode_tp:
@@ -646,19 +665,27 @@ class ModeBackend:
         run_reqs_update_packs: List[InferReqUpdatePack],
         extra_post_req_handle_func: Optional[Callable[[InferReq, int, float], None]] = None,
         nixl_prefill_chuncked_handle_func: Optional[Callable[[InferReq, int, float, int], None]] = None,
+        top_k_ids: List[List[int]] = None,
+        top_k_logprobs: List[List[float]] = None,
     ):
         """
         extra_post_req_handle_func 用于提供在一个请求确定输出的时候，给出额外的后处理操作，主要是用于
         约束输出等模式，设置自己请求内部的状态机的状态，并添加额外的停止判定条件等。
         """
-        for req_obj, next_token_id, next_token_logprob, pack in zip(
-            run_reqs, next_token_ids, next_token_logprobs, run_reqs_update_packs
+        if top_k_ids is None:
+            top_k_ids = [None] * len(run_reqs)
+            top_k_logprobs = [None] * len(run_reqs)
+
+        for req_obj, next_token_id, next_token_logprob, cur_top_k_ids, cur_top_k_logprobs, pack in zip(
+            run_reqs, next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs, run_reqs_update_packs
         ):
             req_obj: InferReq = req_obj
             pack: InferReqUpdatePack = pack
             pack.handle(
                 next_token_id=next_token_id,
                 next_token_logprob=next_token_logprob,
+                top_k_ids=cur_top_k_ids,
+                top_k_logprobs=cur_top_k_logprobs,
                 eos_ids=self.eos_id,
                 extra_post_req_handle_func=extra_post_req_handle_func,
                 is_master_in_dp=self.is_master_in_dp,
@@ -724,7 +751,7 @@ class ModeBackend:
             assert len(run_reqs) == logits.shape[0]
             mask_func(run_reqs, logits)
 
-        next_token_ids, next_token_logprobs = sample(logits, run_reqs, self.eos_id)
+        next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs = sample(logits, run_reqs, self.eos_id)
         b_has_out = None
         if is_prefill:
             b_has_out = g_pin_mem_manager.gen_from_list(
@@ -743,10 +770,13 @@ class ModeBackend:
             next_token_ids=next_token_ids,
             mask=b_has_out,
         )
-        next_token_ids_cpu, next_token_logprobs_cpu = self._async_copy_next_token_infos_to_pin_mem(
-            next_token_ids, next_token_logprobs
-        )
-        return next_token_ids, next_token_ids_cpu, next_token_logprobs_cpu
+        (
+            next_token_ids_cpu,
+            next_token_logprobs_cpu,
+            top_k_ids_cpu,
+            top_k_logprobs_cpu,
+        ) = self._async_copy_next_token_infos_to_pin_mem(next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs)
+        return next_token_ids, next_token_ids_cpu, next_token_logprobs_cpu, top_k_ids_cpu, top_k_logprobs_cpu
 
     def _dp_all_gather_prefill_and_decode_req_num(
         self, prefill_reqs: List[InferReq], decode_reqs: List[InferReq]

--- a/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
+++ b/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
@@ -122,7 +122,13 @@ class DPChunkedPrefillBackend(ModeBackend):
         with torch.cuda.stream(g_infer_context.get_overlap_stream()):
             model_output = self.model.forward(model_input)
             if run_reqs_num > 0:
-                _, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    _,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=model_output.logits[:run_reqs_num],
                     b_req_idx=model_input.b_req_idx[:run_reqs_num],
                     b_mtp_index=model_input.b_mtp_index[:run_reqs_num],
@@ -149,6 +155,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
                 nixl_prefill_chuncked_handle_func=self.nixl_prefill_chuncked_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
             # 第四阶段
             event_pack.notify_pre_post_handle()
@@ -165,7 +173,13 @@ class DPChunkedPrefillBackend(ModeBackend):
         with torch.cuda.stream(g_infer_context.get_overlap_stream()):
             model_output = self.model.forward(model_input)
             if run_reqs_num > 0:
-                _, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    _,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=model_output.logits[:run_reqs_num],
                     b_req_idx=model_input.b_req_idx[:run_reqs_num],
                     b_mtp_index=model_input.b_mtp_index[:run_reqs_num],
@@ -190,6 +204,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 next_token_logprobs=next_token_logprobs_cpu,
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
 
             # 第四阶段
@@ -230,7 +246,13 @@ class DPChunkedPrefillBackend(ModeBackend):
 
             if (req_num0 + req_num1) > 0:
 
-                _, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    _,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=logits,
                     b_req_idx=b_req_idx,
                     b_mtp_index=b_mtp_index,
@@ -258,6 +280,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
                 nixl_prefill_chuncked_handle_func=self.nixl_prefill_chuncked_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
             # 第四阶段
             event_pack.notify_pre_post_handle()
@@ -294,7 +318,13 @@ class DPChunkedPrefillBackend(ModeBackend):
 
             run_reqs = run_reqs0 + run_reqs1
             if (req_num0 + req_num1) > 0:
-                _, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    _,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=logits,
                     b_req_idx=b_req_idx,
                     b_mtp_index=b_mtp_index,
@@ -319,6 +349,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 next_token_logprobs=next_token_logprobs_cpu,
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
 
             # 第四阶段
@@ -341,7 +373,13 @@ class DPChunkedPrefillBackend(ModeBackend):
             b_mtp_index = model_input.b_mtp_index[0:req_num]
 
             if req_num > 0:
-                next_token_ids, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    next_token_ids,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=logits,
                     b_req_idx=b_req_idx,
                     b_mtp_index=b_mtp_index,
@@ -380,6 +418,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
                 nixl_prefill_chuncked_handle_func=self.nixl_prefill_chuncked_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
 
             # 第四阶段
@@ -403,9 +443,14 @@ class DPChunkedPrefillBackend(ModeBackend):
                 b_mtp_index_cpu = b_mtp_index_cpu[0:req_num]
                 b_req_idx = model_input.b_req_idx[0:req_num]
 
-                next_token_ids, next_token_logprobs = sample(logits, run_reqs, self.eos_id)
-                next_token_ids_cpu, next_token_logprobs_cpu = self._async_copy_next_token_infos_to_pin_mem(
-                    next_token_ids, next_token_logprobs
+                next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs = sample(logits, run_reqs, self.eos_id)
+                (
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._async_copy_next_token_infos_to_pin_mem(
+                    next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs
                 )
 
                 # verify the next_token_ids
@@ -620,7 +665,13 @@ class DPChunkedPrefillBackend(ModeBackend):
             b_req_idx = torch.cat((model_input0.b_req_idx[0:req_num0], model_input1.b_req_idx[0:req_num1]), dim=0)
 
             if (req_num0 + req_num1) > 0:
-                next_token_ids, next_token_ids_cpu, next_token_logprobs_cpu = self._sample_and_scatter_token(
+                (
+                    next_token_ids,
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._sample_and_scatter_token(
                     logits=logits,
                     run_reqs=run_reqs,
                     b_req_idx=b_req_idx,
@@ -680,6 +731,8 @@ class DPChunkedPrefillBackend(ModeBackend):
                 run_reqs_update_packs=update_packs,
                 extra_post_req_handle_func=self.extra_post_req_handle_func,
                 nixl_prefill_chuncked_handle_func=self.nixl_prefill_chuncked_handle_func,
+                top_k_ids=top_k_ids_cpu,
+                top_k_logprobs=top_k_logprobs_cpu,
             )
             event_pack.notify_pre_post_handle()
         else:
@@ -714,9 +767,14 @@ class DPChunkedPrefillBackend(ModeBackend):
                 )
                 logits[0:req_num0, :].copy_(logits0[0:req_num0, :], non_blocking=True)
                 logits[req_num0 : (req_num0 + req_num1), :].copy_(logits1[0:req_num1, :], non_blocking=True)
-                next_token_ids, next_token_logprobs = sample(logits, run_reqs, self.eos_id)
-                next_token_ids_cpu, next_token_logprobs_cpu = self._async_copy_next_token_infos_to_pin_mem(
-                    next_token_ids, next_token_logprobs
+                next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs = sample(logits, run_reqs, self.eos_id)
+                (
+                    next_token_ids_cpu,
+                    next_token_logprobs_cpu,
+                    top_k_ids_cpu,
+                    top_k_logprobs_cpu,
+                ) = self._async_copy_next_token_infos_to_pin_mem(
+                    next_token_ids, next_token_logprobs, top_k_ids, top_k_logprobs
                 )
 
                 b_req_idx = torch.cat((model_input0.b_req_idx[0:req_num0], model_input1.b_req_idx[0:req_num1]), dim=0)

--- a/lightllm/server/router/model_infer/mode_backend/generic_post_process.py
+++ b/lightllm/server/router/model_infer/mode_backend/generic_post_process.py
@@ -72,16 +72,7 @@ def sample(logits: torch.Tensor, reqs: List[InferReq], eos_id: List[int] = [2]):
         sampled_index = torch.multinomial(probs_sort, num_samples=1, replacement=True)
         next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index)
         next_token_logprobs = torch.log(torch.gather(probs_sort, dim=1, index=sampled_index))
-
-        # Get top-k for logprobs return
-        # We use the original probs to get the true top-k, not the filtered ones from _top_p_top_k
-        # But for efficiency, we can reuse probs_sort/probs_idx if we are careful,
-        # however _top_p_top_k modifies probs_sort (zeros out pruned items).
-        # So we should re-sort or use the original probs for top-k logprobs.
-        top_k_logprobs_val, top_k_logprobs_idx = _get_top_logprobs(
-            probs, k=20
-        )  # Hardcoded 20 for now to match MAX_TOP_K
-
+        top_k_logprobs_val, top_k_logprobs_idx = _get_top_logprobs(probs, k=20)
         return next_token_ids.view(-1), next_token_logprobs.view(-1), top_k_logprobs_idx, top_k_logprobs_val
 
     elif get_env_start_args().sampling_backend == "sglang_kernel":
@@ -114,7 +105,6 @@ def _top_p_top_k(probs: torch.Tensor, top_ps: torch.Tensor, top_ks: torch.Tensor
 
 
 def _get_top_logprobs(probs: torch.Tensor, k: int = 20):
-    # Given we want the *actual* top-k logprobs of the distribution:
     top_k_logprobs_val, top_k_logprobs_idx = torch.topk(probs, k=k, dim=-1)
     top_k_logprobs_val = torch.log(top_k_logprobs_val)
     return top_k_logprobs_val, top_k_logprobs_idx


### PR DESCRIPTION
# Add top_logprobs support

Came across this repo while messing around on github, I am an intern on aws sage maker jumpstart this fall and wanting to go into the lower level side of things!

## What This PR Does
Implements the [top_logprobs](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/generic_post_process.py:115:0-119:49) feature that was marked as TODO in the codebase. Now when the model generates text, instead of just returning the winning token, it returns the top 20 most likely candidates at each position along with their log probabilities.

## What Changed

### Memory Layer ([req.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/core/objs/req.py:0:0-0:0))
- Added `MAX_TOP_K_LOGPROBS = 20` (matches OpenAI's API limit)
- Created shared memory structures (`shm_top_logprobs_ids`, `shm_top_logprobs_val`) to store top-20 candidates
- Used C structs to allocate 2D arrays: `[sequence_length, 20]` for both IDs and values

### GPU/Sampling Layer ([generic_post_process.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/generic_post_process.py:0:0-0:0))
- Added [_get_top_logprobs()](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/generic_post_process.py:115:0-119:49) helper function
- Modified [sample()](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/generic_post_process.py:8:0-101:33) to calculate top-20 using `torch.topk()` on the original probability distribution
- **Design decision**: Created a new function instead of refactoring [_top_p_top_k()](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/generic_post_process.py:104:0-112:32) because that function destructively modifies probabilities (sets filtered tokens to 0.0) for sampling purposes, but we need the raw probabilities for accurate reporting

### Transport Layer ([base_backend.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/base_backend.py:0:0-0:0), [infer_batch.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/infer_batch.py:0:0-0:0))
- Added GPU→CPU data transfer for top-k arrays
- Modified [_async_copy_next_token_infos_to_pin_mem()](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/mode_backend/base_backend.py:290:4-322:93) to handle the new data
- Updated [set_next_gen_token_id()](cci:1://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/router/model_infer/infer_batch.py:457:4-477:14) to write top 20 data to shared memory

### API Layer ([manager.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/httpserver/manager.py:0:0-0:0), [api_openai.py](cci:7://file:///Users/ahmadbasyouni/LightLLM/lightllm/server/api_openai.py:0:0-0:0))
- HttpServer reads top k data from shared memory
- Formats token IDs to text using the tokenizer
- Returns in OpenAI compatible format

### Backend Integration (`dp_backend/impl.py`)
- Updated all data parallel code paths to thread the new parameters through

### Why Max 20?
Hardcoded to match [OpenAI's API specification](https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_logprobs):
> "An integer between 0 and 20 specifying the number of most likely tokens to return..."

Users can request less (e.g., `top_logprobs=5`), but we always allocate and calculate 20 for simplicity. The API layer filters to the requested amount.

### Why Triton Backend Only?
Currently implemented for the Triton sampling backend because it gives us access to probability tensors in Python. The `sglang_kernel` backend uses fused CUDA kernels where all sampling happens in one black box GPU call, making it harder to extract intermediate probabilities without modifying the kernel itself.

## Testing
Manually tested the code changes on macOS (without GPU)