### PR TITLE
[Feat] Add triton autotuner fallback logic

### DIFF
--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -333,6 +333,11 @@ def make_argument_parser() -> argparse.ArgumentParser:
         help="""inference backend will use the fa3 attention kernel for prefill and decode""",
     )
     parser.add_argument(
+        "--enable_kernel_config_fallback",
+        action="store_true",
+        help="""Whether to enable kernel config fallback when triton version is not compatible.""",
+    )
+    parser.add_argument(
         "--cache_capacity", type=int, default=200, help="cache server capacity for multimodal resources"
     )
     parser.add_argument(

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -131,3 +131,4 @@ class StartArgs:
 
     # kernel setting
     enable_fa3: bool = field(default=False)
+    enable_kernel_config_fallback: bool = field(default=False)


### PR DESCRIPTION
1. 新增启动参数: --enable-kernel-config-fallback (bool)
默认: False (保持原有严格版本匹配模式)；True: 启用版本容错机制，当config不存在时加载最接近版本的config
2. 最接近版本通过os.listdir获取autotune_kernel_configs下面的triton版本路径获得，然后将路径中的版本号抽出，按照与目标版本的差值排序获得
3. 依次扫描排序后的路径下是否存在相应的配置文件，如果存在则加载，若都不存在则报错