### PR TITLE
fix: correct typo 'recieved' to 'received' in log messages

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -300,7 +300,7 @@ async def register_and_keep_alive(websocket: WebSocket):
     client_ip, client_port = websocket.client
     logger.info(f"Client connected from IP: {client_ip}, Port: {client_port}")
     regist_json = json.loads(await websocket.receive_text())
-    logger.info(f"recieved regist_json {regist_json}")
+    logger.info(f"received regist_json {regist_json}")
     await g_objs.httpserver_manager.register_pd(regist_json, websocket)
 
     try:
@@ -329,7 +329,7 @@ async def kv_move_status(websocket: WebSocket):
             # 等待接收消息，设置超时为10秒
             data = await websocket.receive_bytes()
             upkv_status = pickle.loads(data)
-            logger.info(f"recieved upkv_status {upkv_status} from {(client_ip, client_port)}")
+            logger.info(f"received upkv_status {upkv_status} from {(client_ip, client_port)}")
             await g_objs.httpserver_manager.update_req_status(upkv_status)
     except (WebSocketDisconnect, Exception, RuntimeError) as e:
         logger.error(f"kv_move_status client {(client_ip, client_port)} has error {str(e)}")

--- a/lightllm/server/config_server/api_http.py
+++ b/lightllm/server/config_server/api_http.py
@@ -54,7 +54,7 @@ async def websocket_endpoint(websocket: WebSocket):
     client_ip, client_port = websocket.client
     logger.info(f"ws connected from IP: {client_ip}, Port: {client_port}")
     registered_pd_master_obj: PD_Master_Obj = pickle.loads(await websocket.receive_bytes())
-    logger.info(f"recieved registered_pd_master_obj {registered_pd_master_obj}")
+    logger.info(f"received registered_pd_master_obj {registered_pd_master_obj}")
     with registered_pd_master_obj_lock:
         registered_pd_master_objs[registered_pd_master_obj.node_id] = registered_pd_master_obj
 

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -415,7 +415,7 @@ class HttpServerManager:
 
         format_in_time = datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S")
         logger.info(
-            f"recieved req X-Request-Id:{x_request_id} "
+            f"received req X-Request-Id:{x_request_id} "
             f"X-Session-Id:{x_session_id} start_time:{format_in_time} "
             f"lightllm_req_id:{group_request_id} "
         )

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -137,7 +137,7 @@ class HttpServerManagerForPDMaster:
         x_session_id = request.headers.get("X-Session-Id", "")
         format_in_time = datetime.datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S")
         logger.info(
-            f"recieved req X-Request-Id:{x_request_id} "
+            f"received req X-Request-Id:{x_request_id} "
             f"X-Session-Id:{x_session_id} start_time:{format_in_time} "
             f"lightllm_req_id:{group_request_id} "
         )


### PR DESCRIPTION
Fixes 5 instances of the typo 'recieved' → 'received' across 4 server files.