### PR TITLE
fix error response format to match OpenAI API standard

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -117,9 +117,22 @@ app = FastAPI()
 g_objs.app = app
 
 
-def create_error_response(status_code: HTTPStatus, message: str) -> JSONResponse:
+def create_error_response(
+    status_code: HTTPStatus, message: str, err_type: str = None, param: str = None
+) -> JSONResponse:
+    if err_type is None:
+        if status_code.value >= 500:
+            err_type = "InternalServerError"
+        elif status_code == HTTPStatus.NOT_FOUND:
+            err_type = "NotFoundError"
+        else:
+            err_type = "BadRequestError"
+
     g_objs.metric_client.counter_inc("lightllm_request_failure")
-    return JSONResponse({"message": message}, status_code=status_code.value)
+    return JSONResponse(
+        {"error": {"message": message, "type": err_type, "param": param, "code": status_code.value}},
+        status_code=status_code.value,
+    )
 
 
 @app.get("/liveness")

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -58,11 +58,24 @@ from .api_models import (
 logger = init_logger(__name__)
 
 
-def create_error_response(status_code: HTTPStatus, message: str) -> JSONResponse:
+def create_error_response(
+    status_code: HTTPStatus, message: str, err_type: str = None, param: str = None
+) -> JSONResponse:
     from .api_http import g_objs
 
+    if err_type is None:
+        if status_code.value >= 500:
+            err_type = "InternalServerError"
+        elif status_code == HTTPStatus.NOT_FOUND:
+            err_type = "NotFoundError"
+        else:
+            err_type = "BadRequestError"
+
     g_objs.metric_client.counter_inc("lightllm_request_failure")
-    return JSONResponse({"message": message}, status_code=status_code.value)
+    return JSONResponse(
+        {"error": {"message": message, "type": err_type, "param": param, "code": status_code.value}},
+        status_code=status_code.value,
+    )
 
 
 def _process_tool_call_id(


### PR DESCRIPTION
## Summary
- Wrap error responses in the standard `{"error": {"message", "type", "param", "code"}}` envelope to align with vLLM and OpenAI SDK expectations
- Updated both `create_error_response` functions in `api_http.py` and `api_openai.py`
- Auto-maps HTTP status codes to error types: 4xx → `BadRequestError`, 404 → `NotFoundError`, 5xx → `InternalServerError`

## Background
The OpenAI Python SDK and most compatible clients parse `response["error"]["message"]` to extract error details. LightLLM's previous flat `{"message": "..."}` format caused `KeyError` exceptions in client error-handling code.

## Test plan
- [ ] Verify error responses from `/v1/chat/completions` with invalid parameters return the nested `{"error": {...}}` format
- [ ] Verify error responses from `/v1/completions` return the same format
- [ ] Verify OpenAI Python SDK correctly parses error responses without `KeyError`
- [ ] Verify non-OpenAI endpoints in `api_http.py` also return the correct format