### PR TITLE
fix: align /v1/chat/completions SSE stream with OpenAI spec

### DIFF
--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -617,7 +617,7 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
 
-        yield "data: [DONE]\n\n"
+        yield "data: [DONE]\n\n".encode("utf-8")
 
     background_tasks = BackgroundTasks()
     return StreamingResponse(stream_results(), media_type="text/event-stream", background=background_tasks)

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -394,6 +394,7 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
     # Streaming case
     async def stream_results() -> AsyncGenerator[bytes, None]:
         has_emitted_tool_calls: Dict[int, bool] = collections.defaultdict(bool)
+        has_emitted_first_chunk: Dict[int, bool] = collections.defaultdict(bool)
         stream_tool_call_ids: Dict[Tuple[int, int], str] = {}
         from .req_id_generator import convert_sub_id_to_group_id
 
@@ -408,6 +409,23 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
             delta = request_output
             current_finish_reason = finish_status.get_finish_reason()
 
+            # Emit the initial role-only chunk once per choice, as required by the
+            # OpenAI SSE spec: role appears only in the first delta with content="".
+            if not has_emitted_first_chunk[choice_index]:
+                has_emitted_first_chunk[choice_index] = True
+                first_choice = ChatCompletionStreamResponseChoice(
+                    index=choice_index,
+                    delta=DeltaMessage(role="assistant", content=""),
+                    finish_reason=None,
+                )
+                first_chunk = ChatCompletionStreamResponse(
+                    id=group_request_id,
+                    created=created_time,
+                    model=request.model,
+                    choices=[first_choice],
+                )
+                yield f"data: {first_chunk.model_dump_json(exclude_none=True)}\n\n"
+
             # Handle reasoning content
             if get_env_start_args().reasoning_parser and request.separate_reasoning:
                 reasoning_text, delta = _process_reasoning_stream(
@@ -416,7 +434,7 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
                 if reasoning_text:
                     choice_data = ChatCompletionStreamResponseChoice(
                         index=choice_index,
-                        delta=DeltaMessage(role="assistant", reasoning_content=reasoning_text),
+                        delta=DeltaMessage(reasoning_content=reasoning_text),
                         finish_reason=None,
                     )
                     chunk = ChatCompletionStreamResponse(
@@ -437,7 +455,7 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
                 if normal_text and (normal_text.strip() or not has_emitted_tool_calls[sub_req_id]):
                     choice_data = ChatCompletionStreamResponseChoice(
                         index=choice_index,
-                        delta=DeltaMessage(role="assistant", content=normal_text),
+                        delta=DeltaMessage(content=normal_text),
                         finish_reason=None,
                     )
                     chunk = ChatCompletionStreamResponse(
@@ -555,7 +573,7 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
                         )
                         yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
             else:
-                delta_message = DeltaMessage(role="assistant", content=delta)
+                delta_message = DeltaMessage(content=delta)
                 stream_choice = ChatCompletionStreamResponseChoice(
                     index=choice_index, delta=delta_message, finish_reason=None
                 )
@@ -598,6 +616,8 @@ async def chat_completions_impl(request: ChatCompletionRequest, raw_request: Req
                 usage=usage,
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
+
+        yield "data: [DONE]\n\n"
 
     background_tasks = BackgroundTasks()
     return StreamingResponse(stream_results(), media_type="text/event-stream", background=background_tasks)


### PR DESCRIPTION
## Summary

- Add missing `data: [DONE]\n\n` terminator at the end of `/v1/chat/completions` streams — clients following the SSE spec were hanging waiting for this sentinel (the `/v1/completions` endpoint already emitted it, so this was an inconsistency within LightLLM itself)
- Emit a role-only initial chunk `delta: {role: "assistant", content: ""}` once per choice before any content, matching OpenAI API / vLLM behaviour
- Remove `role: "assistant"` from all subsequent delta chunks (plain content, tool-call text, and reasoning paths) so `role` appears only in the first chunk as the spec requires

## Chunk sequence after this fix

```
data: {"delta": {"role": "assistant", "content": ""}, ...}   ← role-only first chunk
data: {"delta": {"content": "Hello"}, ...}                   ← token chunks (no role)
...
data: {"delta": {}, "finish_reason": "stop", ...}            ← finish chunk
data: {"choices": [], "usage": {...}, ...}                    ← only if include_usage=true
data: [DONE]
```

## Test Plan
- [ ] Verify streaming response with a standard SSE client no longer hangs after generation completes
- [ ] Confirm first chunk carries `role: "assistant"` with `content: ""`
- [ ] Confirm subsequent content chunks do not repeat `role`
- [ ] Confirm `data: [DONE]` appears as the final line of the stream
- [ ] Test with `stream_options: {include_usage: true}` — usage chunk precedes `[DONE]`
- [ ] Test tool-call streaming — role-only chunk still emitted first, tool call chunks unaffected