### PR TITLE
feat: default max_new_tokens to remaining max_req_total_len budget

### DIFF
--- a/lightllm/server/core/objs/py_sampling_params.py
+++ b/lightllm/server/core/objs/py_sampling_params.py
@@ -38,7 +38,7 @@ class SamplingParams:
         top_k: int = None,  # -1 is for all
         ignore_eos: bool = False,
         image_max_patch_num: int = -1,
-        max_new_tokens: int = 16384,
+        max_new_tokens: int = -1,
         min_new_tokens: int = 1,
         stop_sequences: Optional[Union[str, List[str], List[List[int]]]] = None,  # 停止句子条件
         skip_special_tokens: bool = True,  # whether to skip special tokens when decoding
@@ -141,11 +141,11 @@ class SamplingParams:
             raise ValueError(f"top_p must in (0.0, 1.0], got {self.top_p}")
         if self.top_k < -1 or self.top_k == 0:
             raise ValueError(f"top_k must be -1 (disable), or at least 1, got {self.top_k}.")
-        if self.max_new_tokens < 1:
+        if self.max_new_tokens != -1 and self.max_new_tokens < 1:
             raise ValueError(f"max_new_tokens must be at least 1, got {self.max_new_tokens}.")
         if self.min_new_tokens < 1:
             raise ValueError(f"min_new_tokens must be at least 1, got {self.min_new_tokens}.")
-        if self.min_new_tokens > self.max_new_tokens:
+        if self.max_new_tokens != -1 and self.min_new_tokens > self.max_new_tokens:
             raise ValueError(
                 f"min_new_tokens must <= max_new_tokens, but got min {self.min_new_tokens}, max {self.max_new_tokens}."
             )

--- a/lightllm/server/core/objs/sampling_params.py
+++ b/lightllm/server/core/objs/sampling_params.py
@@ -345,7 +345,9 @@ class SamplingParams(ctypes.Structure):
         self.top_k = kwargs.get("top_k", SamplingParams._top_k)
         self.ignore_eos = kwargs.get("ignore_eos", False)
         self.image_max_patch_num = kwargs.get("image_max_patch_num", -1)
-        self.max_new_tokens = kwargs.get("max_new_tokens", 16384)
+        # -1 作为哨兵值，表示请求未显式设置 max_new_tokens，后续会在长度校验阶段
+        # 被解析为 max_req_total_len - prompt_tokens，即允许输出到 max_req_total_len。
+        self.max_new_tokens = kwargs.get("max_new_tokens", -1)
         self.min_new_tokens = kwargs.get("min_new_tokens", 1)
         self.input_penalty = kwargs.get("input_penalty", DEFAULT_INPUT_PENALTY)
         self.group_request_id = kwargs.get("group_request_id", -1)
@@ -441,11 +443,11 @@ class SamplingParams(ctypes.Structure):
             raise ValueError(f"top_p must be in (0.0, 1.0], got {self.top_p}")
         if self.top_k < -1 or self.top_k == 0:
             raise ValueError(f"top_k must be -1 (disable), or at least 1, got {self.top_k}.")
-        if self.max_new_tokens < 1:
+        if self.max_new_tokens != -1 and self.max_new_tokens < 1:
             raise ValueError(f"max_new_tokens must be at least 1 , got {self.max_new_tokens}.")
         if self.min_new_tokens < 1:
             raise ValueError(f"min_new_tokens must be at least 1 , got {self.min_new_tokens}.")
-        if self.min_new_tokens > self.max_new_tokens:
+        if self.max_new_tokens != -1 and self.min_new_tokens > self.max_new_tokens:
             raise ValueError(
                 f"min_new_tokens must <= max_new_tokens, but got min {self.min_new_tokens}, max {self.max_new_tokens}."
             )

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -335,12 +335,12 @@ class HttpServerManager:
             )
 
             prompt_tokens = len(prompt_ids)
+            prompt_ids = await self._check_and_repair_length(prompt_ids, sampling_params)
             # 监控
             if group_request_id > 0:
                 self.metric_client.counter_inc("lightllm_request_count")
                 self.metric_client.histogram_observe("lightllm_request_input_length", prompt_tokens)
                 self.metric_client.histogram_observe("lightllm_request_max_new_tokens", sampling_params.max_new_tokens)
-            prompt_ids = await self._check_and_repair_length(prompt_ids, sampling_params)
             self._log_stage_timing(
                 group_request_id,
                 start_time,
@@ -525,6 +525,15 @@ class HttpServerManager:
         if not prompt_ids:
             raise ValueError("prompt_ids is empty")
         prompt_tokens = len(prompt_ids)
+        # 请求未显式传 max_new_tokens 时，默认允许输出到 max_req_total_len
+        if sampling_params.max_new_tokens == -1:
+            remaining = self.max_req_total_len - prompt_tokens
+            if remaining < 1:
+                raise ValueError(
+                    f"the input prompt token len {prompt_tokens} >= max_req_total_len:"
+                    f"{self.max_req_total_len}, no space left for output"
+                )
+            sampling_params.max_new_tokens = remaining
         if prompt_tokens + sampling_params.max_new_tokens > self.max_req_total_len:
             # use long_truncation_mode to truncate long input len req.
             if self.args.long_truncation_mode is None:


### PR DESCRIPTION
## Summary
- Use `-1` as a sentinel when `max_new_tokens` is not explicitly provided by the request.
- Resolve the sentinel to `max_req_total_len - prompt_tokens` during length validation, so requests can output up to the full remaining budget instead of the previous hard-coded `16384`.
- Relax `max_new_tokens` validation in both `py_sampling_params.py` and `sampling_params.py` to allow the `-1` sentinel.

## Test plan
- [ ] Send a request without `max_new_tokens` and verify output is allowed up to `max_req_total_len - prompt_tokens`.
- [ ] Send a request with `prompt_tokens >= max_req_total_len` and verify the new "no space left for output" error is raised.
- [ ] Send a request with an explicit `max_new_tokens` and verify behavior is unchanged.
- [ ] Send a request with `min_new_tokens` set and `max_new_tokens` unset, verify validation passes.