### PR TITLE
fix(httpserver): quiet client-disconnect log path, return 499

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -244,7 +244,8 @@ async def generate(request: Request) -> Response:
         return create_error_response(HTTPStatus.SERVICE_UNAVAILABLE, str(e))
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
@@ -265,7 +266,8 @@ async def generate_stream(request: Request) -> Response:
         return create_error_response(HTTPStatus.SERVICE_UNAVAILABLE, str(e))
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
@@ -281,7 +283,8 @@ async def get_score(request: Request) -> Response:
 
     try:
         return await lightllm_get_score(request, g_objs.httpserver_manager)
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
@@ -313,7 +316,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
         resp = await chat_completions_impl(request, raw_request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     return resp
 
@@ -329,7 +333,8 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
         resp = await completions_impl(request, raw_request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     return resp
 
@@ -344,7 +349,8 @@ async def anthropic_messages(raw_request: Request) -> Response:
 
     try:
         return await anthropic_messages_impl(raw_request)
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
 
 
@@ -390,7 +396,8 @@ async def tokens(request: Request):
             },
             status_code=200,
         )
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, f"error: {str(e)}")

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -281,6 +281,8 @@ async def get_score(request: Request) -> Response:
 
     try:
         return await lightllm_get_score(request, g_objs.httpserver_manager)
+    except ClientDisconnected:
+        return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
 

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -390,6 +390,8 @@ async def tokens(request: Request):
             },
             status_code=200,
         )
+    except ClientDisconnected:
+        return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, f"error: {str(e)}")
 

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -47,7 +47,7 @@ from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
 from lightllm.utils.log_utils import init_logger
-from lightllm.utils.error_utils import ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.envs_utils import get_unique_server_name
 from dataclasses import dataclass
@@ -244,6 +244,8 @@ async def generate(request: Request) -> Response:
         return create_error_response(HTTPStatus.SERVICE_UNAVAILABLE, str(e))
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
+    except ClientDisconnected:
+        return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
@@ -263,6 +265,8 @@ async def generate_stream(request: Request) -> Response:
         return create_error_response(HTTPStatus.SERVICE_UNAVAILABLE, str(e))
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
+    except ClientDisconnected:
+        return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
@@ -307,6 +311,8 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
         resp = await chat_completions_impl(request, raw_request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
+    except ClientDisconnected:
+        return Response(status_code=499)
     return resp
 
 
@@ -321,6 +327,8 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
         resp = await completions_impl(request, raw_request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
+    except ClientDisconnected:
+        return Response(status_code=499)
     return resp
 
 
@@ -332,7 +340,10 @@ async def anthropic_messages(raw_request: Request) -> Response:
         )
     from .api_anthropic import anthropic_messages_impl
 
-    return await anthropic_messages_impl(raw_request)
+    try:
+        return await anthropic_messages_impl(raw_request)
+    except ClientDisconnected:
+        return Response(status_code=499)
 
 
 @app.get("/v1/models", response_model=ModelListResponse)

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -245,7 +245,7 @@ async def generate(request: Request) -> Response:
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
@@ -267,7 +267,7 @@ async def generate_stream(request: Request) -> Response:
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     except Exception as e:
         logger.error("An error occurred: %s", str(e), exc_info=True)
@@ -284,7 +284,7 @@ async def get_score(request: Request) -> Response:
     try:
         return await lightllm_get_score(request, g_objs.httpserver_manager)
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
@@ -317,7 +317,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     return resp
 
@@ -334,7 +334,7 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     return resp
 
@@ -350,7 +350,7 @@ async def anthropic_messages(raw_request: Request) -> Response:
     try:
         return await anthropic_messages_impl(raw_request)
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
 
 
@@ -397,7 +397,7 @@ async def tokens(request: Request):
             status_code=200,
         )
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         return Response(status_code=499)
     except Exception as e:
         return create_error_response(HTTPStatus.EXPECTATION_FAILED, f"error: {str(e)}")

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -69,7 +69,8 @@ async def _safe_stream_wrapper(stream_generator):
     except ValueError as e:
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
-    except ClientDisconnected:
+    except ClientDisconnected as e:
+        logger.error(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.
         return
 

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -30,6 +30,7 @@ from .httpserver.manager import HttpServerManager
 from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
+from lightllm.utils.error_utils import ClientDisconnected
 
 from lightllm.utils.log_utils import init_logger
 from lightllm.server.metrics.manager import MetricClient
@@ -68,6 +69,9 @@ async def _safe_stream_wrapper(stream_generator):
     except ValueError as e:
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
+    except ClientDisconnected:
+        # Client is gone — there's no point yielding more SSE chunks. Stop quietly.
+        return
 
 
 def _serialize_sse_chunk(chunk, choice_nulls=(), response_nulls=()):

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -70,7 +70,7 @@ async def _safe_stream_wrapper(stream_generator):
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
     except ClientDisconnected as e:
-        logger.error(str(e))
+        logger.warning(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.
         return
 

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -664,7 +664,12 @@ class HttpServerManager:
                 pass
 
             if req_status.aborted:
-                raise ClientDisconnected(group_request_id, "aborted by other module")
+                # NOTE: this flag can be set by internal module failures (e.g. the
+                # visual proxy marks shm_req.is_aborted = True on exceptions, which
+                # the recycle loop converts to req_status.aborted), not just client
+                # disconnects. Raise a generic Exception so it surfaces as a server
+                # error instead of being suppressed as a 499.
+                raise Exception(f"req_id {group_request_id} aborted notifyed by other module")
 
             if not self.disable_abort and request is not None and await request.is_disconnected():
                 await self.abort(group_request_id)

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -446,11 +446,8 @@ class HttpServerManager:
                 yield sub_req_id, request_output, metadata, finish_status
 
         except ClientDisconnected as e:
-            # Expected control-flow signal: client disconnected or another module aborted.
-            # ``self.abort(...)`` was already called by the disconnect path (and the recycle
-            # loop releases multimodal resources for in-flight requests), so just log a
-            # one-liner and re-raise — no stack trace, no double-abort.
             logger.warning(f"group_request_id: {group_request_id} {e.reason}")
+            logger.debug(f"group_request_id: {group_request_id} {e.reason}", exc_info=True)
             raise
         except Exception as e:
             logger.error(f"group_request_id: {group_request_id} has exception {str(e)}")

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -450,7 +450,6 @@ class HttpServerManager:
 
             if isinstance(e, ClientDisconnected):
                 logger.warning(f"group_request_id: {group_request_id} {e.reason}")
-                logger.debug(f"group_request_id: {group_request_id} {e.reason}", exc_info=True)
 
             # error need to release multimodel resources.
             # 对于还没有形成正式请求对象管理的多模态资源，需要单独自己释放

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -34,7 +34,7 @@ from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.statics_utils import MovingAverage
 from lightllm.utils.config_utils import get_vocab_size
 from lightllm.utils.envs_utils import get_unique_server_name
-from lightllm.utils.error_utils import NixlPrefillNodeStopGenToken
+from lightllm.utils.error_utils import ClientDisconnected, NixlPrefillNodeStopGenToken
 from rpyc.utils.classic import obtain
 
 logger = init_logger(__name__)
@@ -445,6 +445,13 @@ class HttpServerManager:
 
                 yield sub_req_id, request_output, metadata, finish_status
 
+        except ClientDisconnected as e:
+            # Expected control-flow signal: client disconnected or another module aborted.
+            # ``self.abort(...)`` was already called by the disconnect path (and the recycle
+            # loop releases multimodal resources for in-flight requests), so just log a
+            # one-liner and re-raise — no stack trace, no double-abort.
+            logger.warning(f"group_request_id: {group_request_id} {e.reason}")
+            raise
         except Exception as e:
             logger.error(f"group_request_id: {group_request_id} has exception {str(e)}")
             # error need to release multimodel resources.
@@ -660,11 +667,11 @@ class HttpServerManager:
                 pass
 
             if req_status.aborted:
-                raise Exception(f"req_id {group_request_id} aborted notifyed by other module")
+                raise ClientDisconnected(group_request_id, "aborted by other module")
 
             if not self.disable_abort and request is not None and await request.is_disconnected():
                 await self.abort(group_request_id)
-                raise Exception(f"req_id {group_request_id} disconnected")
+                raise ClientDisconnected(group_request_id)
 
             async with req_status.lock:
                 event.clear()

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -664,11 +664,6 @@ class HttpServerManager:
                 pass
 
             if req_status.aborted:
-                # NOTE: this flag can be set by internal module failures (e.g. the
-                # visual proxy marks shm_req.is_aborted = True on exceptions, which
-                # the recycle loop converts to req_status.aborted), not just client
-                # disconnects. Raise a generic Exception so it surfaces as a server
-                # error instead of being suppressed as a 499.
                 raise Exception(f"req_id {group_request_id} aborted notifyed by other module")
 
             if not self.disable_abort and request is not None and await request.is_disconnected():

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -445,12 +445,13 @@ class HttpServerManager:
 
                 yield sub_req_id, request_output, metadata, finish_status
 
-        except ClientDisconnected as e:
-            logger.warning(f"group_request_id: {group_request_id} {e.reason}")
-            logger.debug(f"group_request_id: {group_request_id} {e.reason}", exc_info=True)
-            raise
-        except Exception as e:
+        except (ClientDisconnected, Exception) as e:
             logger.error(f"group_request_id: {group_request_id} has exception {str(e)}")
+
+            if isinstance(e, ClientDisconnected):
+                logger.warning(f"group_request_id: {group_request_id} {e.reason}")
+                logger.debug(f"group_request_id: {group_request_id} {e.reason}", exc_info=True)
+
             # error need to release multimodel resources.
             # 对于还没有形成正式请求对象管理的多模态资源，需要单独自己释放
             # 已经放入到 req_id_to_out_inf 中的请求对象，由统一的回收循环
@@ -668,7 +669,9 @@ class HttpServerManager:
 
             if not self.disable_abort and request is not None and await request.is_disconnected():
                 await self.abort(group_request_id)
-                raise ClientDisconnected(group_request_id)
+                raise ClientDisconnected(
+                    group_request_id=group_request_id, reason="_wait_to_token_package check network disconnected"
+                )
 
             async with req_status.lock:
                 event.clear()

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -163,6 +163,10 @@ class HttpServerManagerForPDMaster:
 
                 await self.remove_req(group_request_id=block_group_request_id)
 
+        except ClientDisconnected as e:
+            logger.warning(f"group_request_id: {origin_group_request_id} {e.reason}")
+            logger.debug(f"group_request_id: {origin_group_request_id} {e.reason}", exc_info=True)
+            raise
         except BaseException as e:
             logger.error(f"has exception {str(e)}")
             try:
@@ -221,6 +225,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
+                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
                 raise ClientDisconnected(group_request_id)
 
             if await req_status.can_read(self.req_id_to_out_inf):
@@ -259,6 +264,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
+                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
                 raise ClientDisconnected(group_request_id)
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
@@ -296,6 +302,7 @@ class HttpServerManagerForPDMaster:
             raise ServerBusyError()
 
         if await request.is_disconnected():
+            await self.abort(group_request_id, p_node=p_node, d_node=d_node)
             raise ClientDisconnected(group_request_id)
 
         prompt_ids = nixl_np_up_prompt_ids_event.prompt_ids
@@ -324,6 +331,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
+                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
                 raise ClientDisconnected(group_request_id)
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
@@ -373,6 +381,7 @@ class HttpServerManagerForPDMaster:
             p_node, d_node, prompt, sampling_params, multimodal_params, request
         ):
             if await request.is_disconnected():
+                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
                 raise ClientDisconnected(group_request_id)
 
             prompt_tokens = metadata["prompt_tokens"]

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -168,7 +168,6 @@ class HttpServerManagerForPDMaster:
 
             if isinstance(e, ClientDisconnected):
                 logger.warning(f"group_request_id: {origin_group_request_id} {e.reason}")
-                logger.debug(f"group_request_id: {origin_group_request_id} {e.reason}", exc_info=True)
 
             try:
                 await self.abort(block_group_request_id, p_node=p_node, d_node=d_node)

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -163,12 +163,13 @@ class HttpServerManagerForPDMaster:
 
                 await self.remove_req(group_request_id=block_group_request_id)
 
-        except ClientDisconnected as e:
-            logger.warning(f"group_request_id: {origin_group_request_id} {e.reason}")
-            logger.debug(f"group_request_id: {origin_group_request_id} {e.reason}", exc_info=True)
-            raise
-        except BaseException as e:
+        except (ClientDisconnected, BaseException) as e:
             logger.error(f"has exception {str(e)}")
+
+            if isinstance(e, ClientDisconnected):
+                logger.warning(f"group_request_id: {origin_group_request_id} {e.reason}")
+                logger.debug(f"group_request_id: {origin_group_request_id} {e.reason}", exc_info=True)
+
             try:
                 await self.abort(block_group_request_id, p_node=p_node, d_node=d_node)
             except:
@@ -178,39 +179,6 @@ class HttpServerManagerForPDMaster:
         finally:
             await self.remove_req(block_group_request_id)
         return
-
-    async def _wait_event_with_disconnect_check(
-        self,
-        event: asyncio.Event,
-        request: Request,
-        group_request_id: int,
-        p_node: PD_Client_Obj,
-        d_node: PD_Client_Obj,
-        timeout: float = 60.0,
-        poll_interval: float = 1.0,
-    ):
-        # 修复一个旧 bug：原先此处直接 `await asyncio.wait_for(event.wait(), timeout=60)`，
-        # 在等待 KV 移交握手（up_status_event / nixl_np_up_prompt_ids_event）期间完全不
-        # 检查客户端是否已断开。如果客户端在 P 已 prefill 完、D 还没回 ack 的窗口里断开，
-        # master 会把 P 和 D 的资源占满最多 60 秒，然后还会错误地抛 ServerBusyError。
-        #
-        # 这里把同一个 60s 总预算切成多个 poll_interval 的小段：每段超时回来检查一次
-        # request.is_disconnected()，发现断开就立刻通过 self.abort() 给 P/D 各发一个
-        # ABORT_REQ，然后抛 ClientDisconnected，让 API 层返回 499。真超时时仍按原语义
-        # 抛 asyncio.TimeoutError，调用方继续转换为 ServerBusyError。
-        # 效果：最坏情况下 PD 节点在客户端走后被占的时间从 60s 降到约 1s。
-        deadline = time.monotonic() + timeout
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise asyncio.TimeoutError()
-            try:
-                await asyncio.wait_for(event.wait(), timeout=min(poll_interval, remaining))
-                return
-            except asyncio.TimeoutError:
-                if await request.is_disconnected():
-                    await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-                    raise ClientDisconnected(group_request_id)
 
     async def _log_req_header(self, request: Request, group_request_id: int):
         x_request_id = request.headers.get("X-Request-Id", "")
@@ -258,14 +226,9 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                # 修复旧 bug：原先这里只是 `raise Exception(...)`，只能让 master 自己的 HTTP 协程退出，
-                # 但通过 websocket 连过来的 P/D 节点完全收不到 abort 信号，会继续把请求跑完，
-                # 长时间占着 KV cache 与 shm 槽位。这里改为先调用 self.abort(...)，它会通过 P/D 两条
-                # websocket 各发一个 ObjType.ABORT_REQ，让两端立即释放本请求资源；然后再抛
-                # ClientDisconnected，让 API 层走 499 静默路径而不是 417 + ERROR。
-                # 同样的 abort + raise 模式在本文件下面几处 disconnect 检查点也会出现，原因相同。
-                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-                raise ClientDisconnected(group_request_id)
+                raise ClientDisconnected(
+                    group_request_id=group_request_id, reason="fetch_stream prefill period check network disconnected"
+                )
 
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
@@ -286,9 +249,7 @@ class HttpServerManagerForPDMaster:
             return
 
         try:
-            await self._wait_event_with_disconnect_check(
-                up_status_event, request, group_request_id, p_node, d_node, timeout=60
-            )
+            await asyncio.wait_for(up_status_event.wait(), timeout=60)
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} kv move time out err, server is busy now.")
             raise ServerBusyError()
@@ -305,8 +266,9 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-                raise ClientDisconnected(group_request_id)
+                raise ClientDisconnected(
+                    group_request_id=group_request_id, reason="fetch_stream decode period check network disconnected"
+                )
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
                 for sub_req_id, request_output, metadata, finish_status in token_list:
@@ -337,16 +299,15 @@ class HttpServerManagerForPDMaster:
         await p_node.websocket.send_bytes(pickle.dumps((ObjType.REQ, (prompt, sampling_params, multimodal_params))))
 
         try:
-            await self._wait_event_with_disconnect_check(
-                nixl_np_up_prompt_ids_event, request, group_request_id, p_node, d_node, timeout=60
-            )
+            await asyncio.wait_for(nixl_np_up_prompt_ids_event.wait(), timeout=60)
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} wait np up prompt ids time out")
             raise ServerBusyError()
 
         if await request.is_disconnected():
-            await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-            raise ClientDisconnected(group_request_id)
+            raise ClientDisconnected(
+                group_request_id=group_request_id, reason="fetch_nixl_stream prefill period check network disconnected"
+            )
 
         prompt_ids = nixl_np_up_prompt_ids_event.prompt_ids
         logger.info(f"group_request_id: {group_request_id} get np up prompt ids len {len(prompt_ids)}")
@@ -357,9 +318,7 @@ class HttpServerManagerForPDMaster:
         )
 
         try:
-            await self._wait_event_with_disconnect_check(
-                up_status_event, request, group_request_id, p_node, d_node, timeout=60
-            )
+            await asyncio.wait_for(up_status_event.wait(), timeout=60)
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} kv move time out err, server is busy now.")
             raise ServerBusyError()
@@ -376,8 +335,10 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-                raise ClientDisconnected(group_request_id)
+                raise ClientDisconnected(
+                    group_request_id=group_request_id,
+                    reason="fetch_nixl_stream decode period check network disconnected",
+                )
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
                 for sub_req_id, request_output, metadata, finish_status in token_list:
@@ -426,8 +387,9 @@ class HttpServerManagerForPDMaster:
             p_node, d_node, prompt, sampling_params, multimodal_params, request
         ):
             if await request.is_disconnected():
-                await self.abort(group_request_id, p_node=p_node, d_node=d_node)
-                raise ClientDisconnected(group_request_id)
+                raise ClientDisconnected(
+                    group_request_id=group_request_id, reason="_wait_to_token_package check network disconnected"
+                )
 
             prompt_tokens = metadata["prompt_tokens"]
             out_token_counter += 1

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -19,7 +19,7 @@ from lightllm.utils.log_utils import init_logger
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.statics_utils import MovingAverage
 from lightllm.server.httpserver.manager import AsyncQueue
-from lightllm.utils.error_utils import ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
 from lightllm.utils.envs_utils import get_pd_split_max_new_tokens
 from .pd_selector import create_selector
 
@@ -221,7 +221,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                raise Exception(f"req_id {group_request_id} disconnected")
+                raise ClientDisconnected(group_request_id)
 
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
@@ -259,7 +259,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                raise Exception(f"req_id {group_request_id} disconnected")
+                raise ClientDisconnected(group_request_id)
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
                 for sub_req_id, request_output, metadata, finish_status in token_list:
@@ -296,7 +296,7 @@ class HttpServerManagerForPDMaster:
             raise ServerBusyError()
 
         if await request.is_disconnected():
-            raise Exception(f"req_id {group_request_id} disconnected")
+            raise ClientDisconnected(group_request_id)
 
         prompt_ids = nixl_np_up_prompt_ids_event.prompt_ids
         logger.info(f"group_request_id: {group_request_id} get np up prompt ids len {len(prompt_ids)}")
@@ -324,7 +324,7 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
-                raise Exception(f"req_id {group_request_id} disconnected")
+                raise ClientDisconnected(group_request_id)
             if await req_status.can_read(self.req_id_to_out_inf):
                 token_list = await req_status.pop_all_tokens()
                 for sub_req_id, request_output, metadata, finish_status in token_list:
@@ -373,7 +373,7 @@ class HttpServerManagerForPDMaster:
             p_node, d_node, prompt, sampling_params, multimodal_params, request
         ):
             if await request.is_disconnected():
-                raise Exception(f"req_id {group_request_id} disconnected")
+                raise ClientDisconnected(group_request_id)
 
             prompt_tokens = metadata["prompt_tokens"]
             out_token_counter += 1

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -179,6 +179,32 @@ class HttpServerManagerForPDMaster:
             await self.remove_req(block_group_request_id)
         return
 
+    async def _wait_event_with_disconnect_check(
+        self,
+        event: asyncio.Event,
+        request: Request,
+        group_request_id: int,
+        p_node: PD_Client_Obj,
+        d_node: PD_Client_Obj,
+        timeout: float = 60.0,
+        poll_interval: float = 1.0,
+    ):
+        # Wait for `event`, but periodically check whether the client has
+        # disconnected so we can abort PD nodes promptly instead of holding
+        # their resources for the full timeout window.
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise asyncio.TimeoutError()
+            try:
+                await asyncio.wait_for(event.wait(), timeout=min(poll_interval, remaining))
+                return
+            except asyncio.TimeoutError:
+                if await request.is_disconnected():
+                    await self.abort(group_request_id, p_node=p_node, d_node=d_node)
+                    raise ClientDisconnected(group_request_id)
+
     async def _log_req_header(self, request: Request, group_request_id: int):
         x_request_id = request.headers.get("X-Request-Id", "")
         x_session_id = request.headers.get("X-Session-Id", "")
@@ -247,7 +273,9 @@ class HttpServerManagerForPDMaster:
             return
 
         try:
-            await asyncio.wait_for(up_status_event.wait(), timeout=60)
+            await self._wait_event_with_disconnect_check(
+                up_status_event, request, group_request_id, p_node, d_node, timeout=60
+            )
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} kv move time out err, server is busy now.")
             raise ServerBusyError()
@@ -296,7 +324,9 @@ class HttpServerManagerForPDMaster:
         await p_node.websocket.send_bytes(pickle.dumps((ObjType.REQ, (prompt, sampling_params, multimodal_params))))
 
         try:
-            await asyncio.wait_for(nixl_np_up_prompt_ids_event.wait(), timeout=60)
+            await self._wait_event_with_disconnect_check(
+                nixl_np_up_prompt_ids_event, request, group_request_id, p_node, d_node, timeout=60
+            )
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} wait np up prompt ids time out")
             raise ServerBusyError()
@@ -314,7 +344,9 @@ class HttpServerManagerForPDMaster:
         )
 
         try:
-            await asyncio.wait_for(up_status_event.wait(), timeout=60)
+            await self._wait_event_with_disconnect_check(
+                up_status_event, request, group_request_id, p_node, d_node, timeout=60
+            )
         except asyncio.TimeoutError:
             logger.warning(f"group_request_id: {group_request_id} kv move time out err, server is busy now.")
             raise ServerBusyError()

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -189,9 +189,16 @@ class HttpServerManagerForPDMaster:
         timeout: float = 60.0,
         poll_interval: float = 1.0,
     ):
-        # Wait for `event`, but periodically check whether the client has
-        # disconnected so we can abort PD nodes promptly instead of holding
-        # their resources for the full timeout window.
+        # 修复一个旧 bug：原先此处直接 `await asyncio.wait_for(event.wait(), timeout=60)`，
+        # 在等待 KV 移交握手（up_status_event / nixl_np_up_prompt_ids_event）期间完全不
+        # 检查客户端是否已断开。如果客户端在 P 已 prefill 完、D 还没回 ack 的窗口里断开，
+        # master 会把 P 和 D 的资源占满最多 60 秒，然后还会错误地抛 ServerBusyError。
+        #
+        # 这里把同一个 60s 总预算切成多个 poll_interval 的小段：每段超时回来检查一次
+        # request.is_disconnected()，发现断开就立刻通过 self.abort() 给 P/D 各发一个
+        # ABORT_REQ，然后抛 ClientDisconnected，让 API 层返回 499。真超时时仍按原语义
+        # 抛 asyncio.TimeoutError，调用方继续转换为 ServerBusyError。
+        # 效果：最坏情况下 PD 节点在客户端走后被占的时间从 60s 降到约 1s。
         deadline = time.monotonic() + timeout
         while True:
             remaining = deadline - time.monotonic()
@@ -251,6 +258,12 @@ class HttpServerManagerForPDMaster:
         while True:
             await req_status.wait_to_ready()
             if await request.is_disconnected():
+                # 修复旧 bug：原先这里只是 `raise Exception(...)`，只能让 master 自己的 HTTP 协程退出，
+                # 但通过 websocket 连过来的 P/D 节点完全收不到 abort 信号，会继续把请求跑完，
+                # 长时间占着 KV cache 与 shm 槽位。这里改为先调用 self.abort(...)，它会通过 P/D 两条
+                # websocket 各发一个 ObjType.ABORT_REQ，让两端立即释放本请求资源；然后再抛
+                # ClientDisconnected，让 API 层走 499 静默路径而不是 417 + ERROR。
+                # 同样的 abort + raise 模式在本文件下面几处 disconnect 检查点也会出现，原因相同。
                 await self.abort(group_request_id, p_node=p_node, d_node=d_node)
                 raise ClientDisconnected(group_request_id)
 

--- a/lightllm/server/multimodal_params.py
+++ b/lightllm/server/multimodal_params.py
@@ -9,6 +9,7 @@ from io import BytesIO
 from PIL import Image
 from fastapi import Request
 from lightllm.server.embed_cache.utils import read_shm, get_shm_name_data
+from lightllm.utils.error_utils import ClientDisconnected
 from lightllm.utils.multimodal_utils import fetch_resource
 from lightllm.utils.log_utils import init_logger
 
@@ -63,6 +64,10 @@ class AudioItem:
             self._preload_data = audio_values.tobytes()
             return
 
+        except ClientDisconnected:
+            # Preserve client-disconnect signal so the API layer can return 499
+            # without the noisy 'Failed to read audio' error path.
+            raise
         except Exception as e:
             raise ValueError(f"Failed to read audio type={self._type}, data[:100]={self._data[:100]}: {e}!")
 
@@ -148,6 +153,10 @@ class ImageItem:
             self._preload_data = img_data
             return
 
+        except ClientDisconnected:
+            # Preserve client-disconnect signal so the API layer can return 499
+            # without the noisy 'Failed to read image' error path.
+            raise
         except Exception as e:
             raise ValueError(f"Failed to read image type={self._type}, data[:100]={self._data[:100]}: {e}!")
 

--- a/lightllm/server/multimodal_params.py
+++ b/lightllm/server/multimodal_params.py
@@ -64,10 +64,10 @@ class AudioItem:
             self._preload_data = audio_values.tobytes()
             return
 
-        except ClientDisconnected:
+        except ClientDisconnected as e:
             # Preserve client-disconnect signal so the API layer can return 499
-            # without the noisy 'Failed to read audio' error path.
-            raise
+            # without the noisy 'Failed to read audio' error logs.
+            raise e
         except Exception as e:
             raise ValueError(f"Failed to read audio type={self._type}, data[:100]={self._data[:100]}: {e}!")
 
@@ -153,10 +153,10 @@ class ImageItem:
             self._preload_data = img_data
             return
 
-        except ClientDisconnected:
+        except ClientDisconnected as e:
             # Preserve client-disconnect signal so the API layer can return 499
-            # without the noisy 'Failed to read image' error path.
-            raise
+            # without the noisy 'Failed to read image' error logs.
+            raise e
         except Exception as e:
             raise ValueError(f"Failed to read image type={self._type}, data[:100]={self._data[:100]}: {e}!")
 

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -23,6 +23,17 @@ class ServerBusyError(Exception):
         return f"{self.message} (Status code: {self.status_code})"
 
 
+class ClientDisconnected(Exception):
+    """Raised when the client closed the HTTP connection mid-request, or when
+    the request was aborted by another module. This is an expected control-flow
+    signal — handlers should clean up quietly without logging a stack trace."""
+
+    def __init__(self, group_request_id: int, reason: str = "client disconnected"):
+        super().__init__(f"req_id {group_request_id} {reason}")
+        self.group_request_id = group_request_id
+        self.reason = reason
+
+
 class NixlPrefillNodeStopGenToken(Exception):
     def __init__(self, group_request_id, message="Nixl prefill node stop gen token"):
         """

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -1,4 +1,5 @@
 from lightllm.utils.log_utils import init_logger
+from typing import Optional
 
 logger = init_logger(__name__)
 
@@ -30,7 +31,7 @@ class ClientDisconnected(Exception):
     Internal-module aborts (e.g. visual proxy failures) must NOT raise this —
     they should surface as real server errors."""
 
-    def __init__(self, group_request_id: "int | None" = None, reason: str = "client disconnected"):
+    def __init__(self, group_request_id: Optional[int] = None, reason: str = "client disconnected"):
         prefix = f"req_id {group_request_id} " if group_request_id is not None else ""
         super().__init__(f"{prefix}{reason}")
         self.group_request_id = group_request_id

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -30,8 +30,9 @@ class ClientDisconnected(Exception):
     Internal-module aborts (e.g. visual proxy failures) must NOT raise this —
     they should surface as real server errors."""
 
-    def __init__(self, group_request_id: int, reason: str = "client disconnected"):
-        super().__init__(f"req_id {group_request_id} {reason}")
+    def __init__(self, group_request_id: "int | None" = None, reason: str = "client disconnected"):
+        prefix = f"req_id {group_request_id} " if group_request_id is not None else ""
+        super().__init__(f"{prefix}{reason}")
         self.group_request_id = group_request_id
         self.reason = reason
 

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -24,9 +24,11 @@ class ServerBusyError(Exception):
 
 
 class ClientDisconnected(Exception):
-    """Raised when the client closed the HTTP connection mid-request, or when
-    the request was aborted by another module. This is an expected control-flow
-    signal — handlers should clean up quietly without logging a stack trace."""
+    """Raised when the client closed the HTTP connection mid-request, as
+    detected by ``request.is_disconnected()``. This is an expected control-flow
+    signal — handlers should clean up quietly without logging a stack trace.
+    Internal-module aborts (e.g. visual proxy failures) must NOT raise this —
+    they should surface as real server errors."""
 
     def __init__(self, group_request_id: int, reason: str = "client disconnected"):
         super().__init__(f"req_id {group_request_id} {reason}")

--- a/lightllm/utils/multimodal_utils.py
+++ b/lightllm/utils/multimodal_utils.py
@@ -6,6 +6,7 @@ from PIL import Image
 from io import BytesIO
 from fastapi import Request
 from functools import lru_cache
+from lightllm.utils.error_utils import ClientDisconnected
 from lightllm.utils.log_utils import init_logger
 
 logger = init_logger(__name__)
@@ -53,7 +54,7 @@ async def fetch_resource(url, request: Request, timeout, proxy=None):
         async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
             if request is not None and await request.is_disconnected():
                 await response.aclose()
-                raise Exception("Request disconnected. User cancelled download.")
+                raise ClientDisconnected(reason=f"client disconnected during download of {url}")
             ans_bytes.append(chunk)
             # 接收的数据不能大于128M
             if len(ans_bytes) > 128:


### PR DESCRIPTION
## Summary
- Add `ClientDisconnected` exception (`lightllm/utils/error_utils.py`) and raise it from the polling loops in both `httpserver/manager.py` and `httpserver_for_pd_master/manager.py` instead of generic `Exception("... disconnected")`.
- Catch `ClientDisconnected` ahead of the generic handler in `HttpServerManager.generate`: log a single WARNING line and re-raise without calling `self.abort` again (the disconnect path already aborted).
- Catch `ClientDisconnected` in the FastAPI route handlers (`/generate`, `/generate_stream`, `/v1/chat/completions`, `/v1/completions`, `/v1/messages`) and return HTTP 499 instead of falling through to the generic `Exception` handler that emits 417 + a traceback.
- Catch `ClientDisconnected` in the SSE wrapper (`api_openai._safe_stream_wrapper`) and exit quietly so a closed client doesn't trigger a stream-tail traceback.

## Context
The underlying root cause — `BaseHTTPMiddleware`'s access-log decorator swallowing `http.disconnect` so `Request.is_disconnected()` never flipped — was already fixed upstream in #1282 (the ASGI-class `_AccessLogMiddleware`). Once disconnect detection actually fires, the existing code path raises a generic `Exception` that falls through every layer's logger; this PR is the cleanup that follows from that fix.

## Server logs (before vs after)

### Before
```
WARNING 05-06 02:51:38 [manager.py:767] aborted group_request_id 3912
ERROR 05-06 02:51:38 [manager.py:449] group_request_id: 3912 has exception req_id 3912 disconnected
WARNING 05-06 02:51:38 [manager.py:767] aborted group_request_id 3912
ERROR 05-06 02:51:38 [api_http.py:248] An error occurred: req_id 3912 disconnected
ERROR 05-06 02:51:38 [api_http.py:248] Traceback (most recent call last):
ERROR 05-06 02:51:38 [api_http.py:248]   File "/lightllm/lightllm/server/api_http.py", line 241, in generate
ERROR 05-06 02:51:38 [api_http.py:248]     return await g_objs.g_generate_func(request, g_objs.httpserver_manager)
ERROR 05-06 02:51:38 [api_http.py:248]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-06 02:51:38 [api_http.py:248]   File "/lightllm/lightllm/server/api_lightllm.py", line 56, in lightllm_generate
ERROR 05-06 02:51:38 [api_http.py:248]     async for sub_req_id, request_output, metadata, finish_status in results_generator:
ERROR 05-06 02:51:38 [api_http.py:248]   File "/lightllm/lightllm/server/httpserver/manager.py", line 457, in generate
ERROR 05-06 02:51:38 [api_http.py:248]     raise e
ERROR 05-06 02:51:38 [api_http.py:248]   File "/lightllm/lightllm/server/httpserver/manager.py", line 440, in generate
ERROR 05-06 02:51:38 [api_http.py:248]     async for sub_req_id, request_output, metadata, finish_status in results_generator:
ERROR 05-06 02:51:38 [api_http.py:248]   File "/lightllm/lightllm/server/httpserver/manager.py", line 667, in _wait_to_token_package
ERROR 05-06 02:51:38 [api_http.py:248]     raise Exception(f"req_id {group_request_id} disconnected")
ERROR 05-06 02:51:38 [api_http.py:248] Exception: req_id 3912 disconnected
```

### After
```
WARNING 05-06 02:57:24 [manager.py:774] aborted group_request_id 1792
WARNING 05-06 02:57:24 [manager.py:453] group_request_id: 1792 client disconnected
INFO 05-06 02:57:24 [api_http.py:149] POST /generate 499
```

## Test plan
- [x] `python -c "import ast; [ast.parse(open(f).read()) for f in (...)]"` passes on all five touched files.
- [ ] Manual: hit `/generate` with a long-running prompt, close the client mid-stream, confirm server logs match the "After" block above and that no traceback is emitted.
- [ ] Manual: same drill against a streaming endpoint (`/v1/chat/completions` with `stream=true`) — confirm SSE wrapper exits without dumping a traceback.
- [ ] Manual: PD-master mode — disconnect during prefill/decode and confirm pd-master manager raises `ClientDisconnected` instead of `Exception`.