### PR TITLE
feat(triton): support 256 headdim in attention decode kernels

### DIFF
--- a/lightllm/common/basemodel/triton_kernel/alibi_att/context_flashattention_nopad.py
+++ b/lightllm/common/basemodel/triton_kernel/alibi_att/context_flashattention_nopad.py
@@ -132,7 +132,7 @@ def context_attention_fwd(
     # shape constraints
     Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
     assert Lq == Lk and Lk == Lv
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
 
     sm_scale = 1.0 / (Lq ** 0.5)
     batch, head = b_seq_len.shape[0], q.shape[1]

--- a/lightllm/common/basemodel/triton_kernel/alibi_att/token_attention_nopad_att1.py
+++ b/lightllm/common/basemodel/triton_kernel/alibi_att/token_attention_nopad_att1.py
@@ -73,11 +73,11 @@ def _fwd_kernel_token_att1(
 
 @torch.no_grad()
 def token_att_fwd(q, k, att_out, alibi, Req_to_tokens, B_req_idx, B_Start_Loc, B_Seqlen, max_len_in_batch):
-    BLOCK = 32
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    BLOCK = 16 if Lk == 256 else 32
     sm_scale = 1.0 / (Lk ** 0.5)
 
     batch, head_num = B_req_idx.shape[0], q.shape[1]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/flash_decoding/gqa_flash_decoding_stage1.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/flash_decoding/gqa_flash_decoding_stage1.py
@@ -185,7 +185,10 @@ def flash_decode_stage1(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    if Lk == 256:
+        BLOCK_N = min(BLOCK_N, 16)
+    assert BLOCK_SEQ % BLOCK_N == 0
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, kv_head_num = B_req_idx.shape[0], k.shape[1]
     block_num = mid_out.shape[2]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/flash_decoding/gqa_flash_decoding_stage2.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/flash_decoding/gqa_flash_decoding_stage2.py
@@ -56,7 +56,7 @@ def _fwd_kernel_flash_decode_stage2(
 @torch.no_grad()
 def flash_decode_stage2(mid_out, mid_out_logexpsum, B_Seqlen, out, block_seq):
     Lk = mid_out.shape[-1]
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
     batch, head_num = mid_out.shape[0], mid_out.shape[1]
     grid = (batch, head_num)
     block_num = mid_out.shape[2]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/gqa_decode_flashattention_nopad.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/gqa/gqa_decode_flashattention_nopad.py
@@ -116,11 +116,11 @@ def _fwd_kernel(
 @torch.no_grad()
 def gqa_decode_attention_fwd(q, k, v, o, req_to_tokens, b_req_idx, b_seq_len):
 
-    BLOCK = 32
     # shape constraints
     Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
     assert Lq == Lk and Lk == Lv
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    BLOCK = 16 if Lk == 256 else 32
 
     sm_scale = 1.0 / (Lq ** 0.5)  # 计算scale系数
     batch = b_req_idx.shape[0]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int4kv/int4kv_flash_decoding_stage1.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int4kv/int4kv_flash_decoding_stage1.py
@@ -205,7 +205,10 @@ def int4kv_flash_decode_stage1(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1] * 2
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    if Lk == 256:
+        BLOCK_N = min(BLOCK_N, 16)
+    assert BLOCK_SEQ % BLOCK_N == 0
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, kv_head_num = B_req_idx.shape[0], k.shape[1]
     grid_block_num = mid_out.shape[2]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage1.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage1.py
@@ -276,7 +276,10 @@ def flash_decode_stage1(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    if Lk == 256:
+        BLOCK_N = min(BLOCK_N, 16)
+    assert BLOCK_SEQ % BLOCK_N == 0
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, kv_head_num = B_req_idx.shape[0], k.shape[1]
     grid = (batch, kv_head_num, triton.cdiv(max_len_in_batch, BLOCK_SEQ))

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage2.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage2.py
@@ -250,7 +250,10 @@ def flash_decode_stage2(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    if Lk == 256:
+        BLOCK_N = min(BLOCK_N, 16)
+    assert BLOCK_SEQ % BLOCK_N == 0
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, kv_head_num = B_req_idx.shape[0], k.shape[1]
     grid = (batch, kv_head_num, triton.cdiv(max_len_in_batch, BLOCK_SEQ))

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage3.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/int8kv_flash_decoding_diverse_stage3.py
@@ -67,7 +67,7 @@ def flash_diverse_decode_stage3(
     block_seq: int,
 ):
     Lk = mid_out.shape[-1]
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
     batch, head_num = mid_out.shape[0], mid_out.shape[1]
     grid = (batch, head_num)
 

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/normal/int8kv_flash_decoding_stage1.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/normal/int8kv_flash_decoding_stage1.py
@@ -213,7 +213,10 @@ def flash_decode_stage1(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
+    if Lk == 256:
+        BLOCK_N = min(BLOCK_N, 16)
+    assert BLOCK_SEQ % BLOCK_N == 0
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, kv_head_num = B_req_idx.shape[0], k.shape[1]
     gqa_group_size = q.shape[1] // k.shape[1]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/normal/int8kv_flash_decoding_stage2.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/int8kv/normal/int8kv_flash_decoding_stage2.py
@@ -62,7 +62,7 @@ def flash_decode_stage2(
     block_seq: int,
 ):
     Lk = mid_out.shape[-1]
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
     batch, head_num = mid_out.shape[0], mid_out.shape[1]
     grid = (batch, head_num)
     block_num = mid_out.shape[2]

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/mha/flash_decoding/flash_decoding_stage1.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/mha/flash_decoding/flash_decoding_stage1.py
@@ -112,7 +112,7 @@ def flash_decode_stage1(
     # shape constraints
     Lq, Lk = q.shape[-1], k.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
     sm_scale = 1.0 / (Lk ** 0.5)
     batch, head_num = B_req_idx.shape[0], q.shape[1]
     grid = (batch, head_num, triton.cdiv(max_len_in_batch, BLOCK_SEQ))

--- a/lightllm/common/basemodel/triton_kernel/att/decode_att/mha/flash_decoding/flash_decoding_stage2.py
+++ b/lightllm/common/basemodel/triton_kernel/att/decode_att/mha/flash_decoding/flash_decoding_stage2.py
@@ -55,7 +55,7 @@ def _fwd_kernel_flash_decode_stage2(
 @torch.no_grad()
 def flash_decode_stage2(mid_out, mid_out_logexpsum, B_Seqlen, out, block_seq):
     Lk = mid_out.shape[-1]
-    assert Lk in {16, 32, 64, 128}
+    assert Lk in {16, 32, 64, 128, 256}
     batch, head_num = mid_out.shape[0], mid_out.shape[1]
     grid = (batch, head_num)
 


### PR DESCRIPTION
## Summary

Enable `head_dim = 256` in the Triton attention kernels by adding `256` to the supported `Lk` set across the affected decode + alibi prefill paths and tuning the block sizes so the per-block working set still fits in shared memory.

Touched paths (all under `lightllm/common/basemodel/triton_kernel/`):

- `alibi_att/token_attention_nopad_att1.py` — decode
- `alibi_att/context_flashattention_nopad.py` — **prefill** (assertion extension only — block sizes match the non-alibi prefill kernel which already accepts 256)
- `att/decode_att/gqa/flash_decoding/{gqa_flash_decoding_stage1,gqa_flash_decoding_stage2}.py`
- `att/decode_att/gqa/gqa_decode_flashattention_nopad.py`
- `att/decode_att/int4kv/int4kv_flash_decoding_stage1.py`
- `att/decode_att/int8kv/{int8kv_flash_decoding_diverse_stage1,_stage2,_stage3}.py`
- `att/decode_att/int8kv/normal/{int8kv_flash_decoding_stage1,_stage2}.py`
- `att/decode_att/mha/flash_decoding/{flash_decoding_stage1,flash_decoding_stage2}.py`

The pattern is the same in every decode kernel:

- Stage-1 / nopad kernels: extend `assert Lk in {16, 32, 64, 128}` to include `256`, and when `Lk == 256` clamp `BLOCK_N` (or `BLOCK`) down to `16` (from the default 32) so the K/V tile still fits in SRAM. `BLOCK_SEQ % BLOCK_N == 0` is re-asserted after the clamp.
- Stage-2 / stage-3 reduction kernels: just extend the `Lk` assertion — no block-size change needed since they only touch `mid_out`.

For ALiBi prefill, only the assertion is extended; the existing `BLOCK = 128` matches the non-alibi prefill kernel (`att/prefill_att/context_flashattention_nopad.py`) which already accepts 256 with the same block size.

The legacy `lightllm/models/llama/triton_kernel/token_attention_nopad_att1.py::token_att_fwd_int8k` (which still rejects 256) was intentionally left out — it has no callers anywhere in the tree.

## Test plan

- [ ] Run a non-alibi model with `head_dim = 256` end-to-end and verify decode produces sensible logits.
- [ ] Run an alibi model (or a 256-headdim test fixture exercising the alibi prefill kernel) and verify prefill no longer asserts.
- [ ] Confirm existing 16/32/64/128 head-dim paths are unchanged: `BLOCK_N` is only clamped when `Lk == 256`, the default branch keeps the original block size.
- [ ] Spot-check int4kv / int8kv decode paths on a quantized checkpoint with head_dim 256.