### PR TITLE
fix: honor visual infer batch size

### DIFF
--- a/lightllm/server/visualserver/manager.py
+++ b/lightllm/server/visualserver/manager.py
@@ -84,7 +84,7 @@ class VisualManager:
                     "visual_nccl_port": self.args.visual_nccl_ports[dp_rank_id],
                     "quant_type": self.args.vit_quant_type,
                     "quant_cfg": self.args.vit_quant_cfg,
-                    "max_batch_size": min(self.infer_batch_size // self.vit_dp, 1),
+                    "max_batch_size": max(self.infer_batch_size // self.vit_dp, 1),
                     "vit_attn_backend": self.vit_attn_backend,
                 }
                 init_model_ret.append(self.model_rpcs[dp_rank_id][tp_rank_id].init_model(kvargs))

--- a/lightllm/server/visualserver/model_infer/model_rpc.py
+++ b/lightllm/server/visualserver/model_infer/model_rpc.py
@@ -47,7 +47,7 @@ class VisualModelRpcServer(rpyc.Service):
         #     "visual_nccl_port": self.args.visual_nccl_ports[dp_rank_id],
         #     "quant_type": self.args.vit_quant_type,
         #     "quant_cfg": self.args.vit_quant_cfg,
-        #     "max_batch_size": min(self.infer_batch_size // self.vit_dp, 1),
+        #     "max_batch_size": max(self.infer_batch_size // self.vit_dp, 1),
         #     "vit_attn_backend": self.vit_attn_backend,
         # }
 

--- a/lightllm/server/visualserver/visual_only_manager.py
+++ b/lightllm/server/visualserver/visual_only_manager.py
@@ -116,7 +116,7 @@ class VisualOnlyManager(rpyc.Service):
                     "visual_nccl_port": self.args.visual_nccl_ports[dp_rank_id],
                     "quant_type": self.args.vit_quant_type,
                     "quant_cfg": self.args.vit_quant_cfg,
-                    "max_batch_size": min(self.infer_batch_size // self.vit_dp, 1),
+                    "max_batch_size": max(self.infer_batch_size // self.vit_dp, 1),
                     "vit_attn_backend": self.vit_attn_backend,
                 }
                 init_model_ret.append(self.model_rpcs[dp_rank_id][tp_rank_id].init_model(kvargs))


### PR DESCRIPTION
## Summary
- Fix ViT worker max_batch_size calculation so --visual_infer_batch_size is honored per visual DP rank
- Update the nearby kvargs example comment to match the runtime calculation

## Problem
The previous code used min(self.infer_batch_size // self.vit_dp, 1), which clamps every valid configuration to 1 because startup validation already requires infer_batch_size // vit_dp >= 1.

## Verification
- python -m py_compile lightllm/server/visualserver/manager.py lightllm/server/visualserver/visual_only_manager.py lightllm/server/visualserver/model_infer/model_rpc.py
- git diff --check