### PR TITLE
fix: replace pickle deserialization with RestrictedUnpickler in PD WebSocket endpoints (CVE-2026-26220)

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -25,8 +25,9 @@ import requests
 import base64
 import os
 from io import BytesIO
-import pickle
+import pickle  # kept for non-network uses; WebSocket paths use safe_pickle
 import setproctitle
+from lightllm.utils.safe_pickle import safe_loads as _safe_pickle_loads
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 import ujson as json
@@ -426,7 +427,7 @@ async def register_and_keep_alive(websocket: WebSocket):
         while True:
             # 等待接收消息，设置超时为10秒
             data = await websocket.receive_bytes()
-            obj = pickle.loads(data)
+            obj = _safe_pickle_loads(data)  # CVE-2026-26220: restricted unpickling
             await g_objs.httpserver_manager.put_to_handle_queue(obj)
 
     except (WebSocketDisconnect, Exception, RuntimeError) as e:
@@ -447,7 +448,7 @@ async def kv_move_status(websocket: WebSocket):
         while True:
             # 等待接收消息，设置超时为10秒
             data = await websocket.receive_bytes()
-            upkv_status = pickle.loads(data)
+            upkv_status = _safe_pickle_loads(data)  # CVE-2026-26220: restricted unpickling
             logger.info(f"received upkv_status {upkv_status} from {(client_ip, client_port)}")
             await g_objs.httpserver_manager.update_req_status(upkv_status)
     except (WebSocketDisconnect, Exception, RuntimeError) as e:

--- a/lightllm/server/httpserver/pd_loop.py
+++ b/lightllm/server/httpserver/pd_loop.py
@@ -1,6 +1,7 @@
 import asyncio
-import pickle
+import pickle  # kept for outbound pickle.dumps; inbound paths use safe_pickle
 import websockets
+from lightllm.utils.safe_pickle import safe_loads as _safe_pickle_loads
 import ujson as json
 import socket
 import httpx
@@ -103,7 +104,7 @@ async def _pd_handle_task(manager: HttpServerManager, pd_master_obj: PD_Master_O
                 # 接收 pd master 发来的请求，并推理后，将生成的token转发回pd master。
                 while True:
                     recv_bytes = await websocket.recv()
-                    obj = pickle.loads(recv_bytes)
+                    obj = _safe_pickle_loads(recv_bytes)  # CVE-2026-26220: restricted unpickling
                     if obj[0] == ObjType.REQ:
                         prompt, sampling_params, multimodal_params = obj[1]
                         group_req_id = sampling_params.group_request_id
@@ -183,7 +184,7 @@ async def _get_pd_master_objs(args: StartArgs) -> Optional[Dict[int, PD_Master_O
             response = await client.get(uri)
             if response.status_code == 200:
                 base64data = response.json()["data"]
-                id_to_pd_master_obj = pickle.loads(base64.b64decode(base64data))
+                id_to_pd_master_obj = _safe_pickle_loads(base64.b64decode(base64data))  # CVE-2026-26220: restricted unpickling
                 return id_to_pd_master_obj
             else:
                 logger.error(f"get pd_master_objs error {response.status_code}")

--- a/lightllm/utils/safe_pickle.py
+++ b/lightllm/utils/safe_pickle.py
@@ -1,0 +1,78 @@
+"""
+safe_pickle.py — Restricted unpickling for LightLLM PD WebSocket endpoints.
+
+CVE-2026-26220: The PD disaggregation WebSocket endpoints and the config-server
+HTTP response handler called pickle.loads() on untrusted network data, enabling
+unauthenticated remote code execution.  This module replaces those bare
+pickle.loads() calls with a RestrictedUnpickler that whitelists only the
+internal LightLLM dataclass modules that legitimately flow through those
+channels.
+
+Usage:
+    from lightllm.utils.safe_pickle import safe_loads
+
+    obj = safe_loads(data)   # raises UnpicklingError for non-whitelisted types
+"""
+
+import io
+import pickle
+
+# ---------------------------------------------------------------------------
+# Allowlist: (module, name) pairs permitted to be deserialized.
+# Keep this list minimal — add entries only when a new type is deliberately
+# added to a PD WebSocket protocol message.
+# ---------------------------------------------------------------------------
+_ALLOWED_MODULES: dict[str, set[str]] = {
+    # Built-in safe types used as containers / primitives
+    "builtins": {"dict", "list", "tuple", "set", "int", "float", "str", "bool", "bytes", "NoneType"},
+    # LightLLM PD protocol structures
+    "lightllm.server.pd_io_struct": {
+        "ObjType",
+        "NodeRole",
+        "PD_Master_Obj",
+        "PD_Client_Obj",
+        "_PD_Client_RunStatus",
+        "UpKVStatus",
+        "NixlUpKVStatus",
+        "DecodeNodeInfo",
+        "NIXLDecodeNodeInfo",
+        "KVMoveTask",
+        "KVMoveTaskGroup",
+        "PDTransJoinInfo",
+        "PDTransLeaveInfo",
+        "NIXLChunckedTransTask",
+        "NIXLChunckedTransTaskRet",
+        "NIXLChunckedTransTaskGroup",
+    },
+    # SamplingParams / StartArgs sent inside REQ messages
+    "lightllm.server.core.objs.py_sampling_params": {"SamplingParams"},
+    "lightllm.server.core.objs.sampling_params": {"SamplingParams"},
+    "lightllm.server.core.objs.start_args_type": {"StartArgs"},
+    # Multimodal params can accompany REQ messages
+    "lightllm.server.multimodal_params": {"MultimodalParams"},
+    # enum base class (needed for ObjType / NodeRole reconstruction)
+    "enum": {"Enum"},
+}
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that raises UnpicklingError for any non-whitelisted class."""
+
+    def find_class(self, module: str, name: str):
+        allowed_names = _ALLOWED_MODULES.get(module)
+        if allowed_names is not None and name in allowed_names:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to deserialize {module}.{name}: not in safe_pickle allowlist. "
+            f"This may indicate an attempted pickle-based RCE exploit (CVE-2026-26220)."
+        )
+
+
+def safe_loads(data: bytes) -> object:
+    """
+    Drop-in replacement for pickle.loads() that only permits whitelisted types.
+
+    Raises pickle.UnpicklingError if the payload attempts to instantiate a
+    class outside the allowlist.
+    """
+    return _RestrictedUnpickler(io.BytesIO(data)).load()


### PR DESCRIPTION
## Security Fix: CVE-2026-26220 — Unauthenticated RCE via pickle.loads() in PD WebSocket Endpoints

### Vulnerability

LightLLM's PD (prefill-decode) disaggregation mode exposes WebSocket endpoints that called `pickle.loads()` directly on binary frames received from the network, with **no authentication**. Any attacker who can reach the PD master network port can send a crafted pickle payload and achieve **arbitrary code execution** on the host.

**CVSS 4.0:** 9.3 Critical (AV:N/AC:L/AT:N/PR:N/UI:N)
**CWE:** CWE-502 — Deserialization of Untrusted Data

### Vulnerable callsites (all replaced by this PR)

| File | Line | Endpoint / context |
|------|------|--------------------|
| `lightllm/server/api_http.py` | 429 | `/pd_register` WebSocket — `pickle.loads(data)` |
| `lightllm/server/api_http.py` | 450 | `/kv_move_status` WebSocket — `pickle.loads(data)` |
| `lightllm/server/httpserver/pd_loop.py` | 106 | PD worker receiving from PD master — `pickle.loads(recv_bytes)` |
| `lightllm/server/httpserver/pd_loop.py` | 186 | Config-server HTTP response — `pickle.loads(base64.b64decode(...))` |

Note: PR #979 (July 2025) only patched `embed_cache/manager.py` and left these WebSocket callsites untouched.

### Fix

Introduces `lightllm/utils/safe_pickle.py` — a `RestrictedUnpickler` (subclass of `pickle.Unpickler`) that overrides `find_class()` to raise `UnpicklingError` for any module/class not in an explicit allowlist. The allowlist contains only the internal LightLLM dataclass modules that legitimately flow through these channels (`pd_io_struct`, `py_sampling_params`, `multimodal_params`, and safe builtins).

All four vulnerable `pickle.loads()` calls are replaced with `safe_loads()` from this module. The **pickle wire format is unchanged** — no protocol migration required, no breaking changes.

### No breaking changes

- Pickle protocol and binary frame format are preserved unchanged.
- Only class instantiation is restricted; legitimate LightLLM objects continue to deserialize normally.
- Outbound `pickle.dumps()` calls are not touched (they are not a vulnerability).

### Related

- Closes #1213 (CVE-2026-26220 issue report)
- Supersedes #1217 (JSON replacement — breaks complex types) and #1219 (also RestrictedUnpickler, different scope)