### PR TITLE
fix: correct 'Unsupport' typo to 'Unsupported' in error messages

### DIFF
--- a/lightllm/models/gemma3/gemma3_visual.py
+++ b/lightllm/models/gemma3/gemma3_visual.py
@@ -127,7 +127,7 @@ class Gemma3VisionModel:
                 t = self.image_processor.preprocess(image_data, return_tensors="pt")["pixel_values"]
                 img_tensors.append(t)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             cur_num = img_tensors[-1].shape[0]
             valid_ids.append([valid_id, valid_id + cur_num])

--- a/lightllm/models/internvl/internvl_visual.py
+++ b/lightllm/models/internvl/internvl_visual.py
@@ -58,7 +58,7 @@ class InternVLVisionModel:
                 t = self.load_image_func(image_data, max_num=img.extra_params["image_patch_max_num"])
                 img_tensors.append(t)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             cur_num = img_tensors[-1].shape[0]
             valid_ids.append([valid_id, valid_id + cur_num])

--- a/lightllm/models/llava/llava_visual.py
+++ b/lightllm/models/llava/llava_visual.py
@@ -138,7 +138,7 @@ class LlavaVisionModel:
                 t = self.image_processor.preprocess(image_data, return_tensors="pt")["pixel_values"]
                 img_tensors.append(t)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             cur_num = img_tensors[-1].shape[0]
             valid_ids.append([valid_id, valid_id + cur_num])

--- a/lightllm/models/qwen2_5_vl/qwen2_5_visual.py
+++ b/lightllm/models/qwen2_5_vl/qwen2_5_visual.py
@@ -221,7 +221,7 @@ class Qwen2_5_VisionTransformerPretrainedModel(nn.Module):
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
         return
 
     def rot_pos_emb(self, grid_thw):
@@ -346,7 +346,7 @@ class Qwen2_5_VisionTransformerPretrainedModel(nn.Module):
             image_data = resize_image(image_data)
             pixel_values, image_grid_thw = self.processor.preprocess(image_data)
         else:
-            raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+            raise Exception("Unsupported input types: {} for {}".format(type(img), img))
         return pixel_values.to(dtype=self.data_type), image_grid_thw
 
     def load_model(self, weight_dir):
@@ -387,7 +387,7 @@ class Qwen2_5_VisionTransformerPretrainedModel(nn.Module):
                 img_tensors.append(pixel_values)
                 img_grids.append(image_grid_thw)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             # must devide merge_length
             cur_num = img_tensors[-1].shape[0] // (self.spatial_merge_size ** 2)

--- a/lightllm/models/qwen2_vl/qwen2_visual.py
+++ b/lightllm/models/qwen2_vl/qwen2_visual.py
@@ -235,7 +235,7 @@ class Qwen2VisionTransformerPretrainedModel(nn.Module):
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
         return
 
     def load_model(self, weight_dir):
@@ -319,7 +319,7 @@ class Qwen2VisionTransformerPretrainedModel(nn.Module):
                 img_tensors.append(pixel_values)
                 img_grids.append(image_grid_thw)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             # must devide merge_length
             cur_num = img_tensors[-1].shape[0] // (self.spatial_merge_size ** 2)

--- a/lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_audio.py
+++ b/lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_audio.py
@@ -217,7 +217,7 @@ class Qwen3OmniMoeAudioEncoder(nn.Module):
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
         return
 
     def _freeze_parameters(self):

--- a/lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_visual.py
+++ b/lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_visual.py
@@ -204,7 +204,7 @@ class Qwen3OmniMoeVisionTransformerPretrainedModel(nn.Module):
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
         return
 
     def concat_img_embed_and_deepstack_features(self, image_embed, deepstack_feature_lists, valid_ids):
@@ -388,7 +388,7 @@ class Qwen3OmniMoeVisionTransformerPretrainedModel(nn.Module):
                 img_tensors.append(pixel_values)
                 img_grids.append(image_grid_thw)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             # must devide merge_length
             cur_num = img_tensors[-1].shape[0] // (self.spatial_merge_size ** 2)

--- a/lightllm/models/qwen3_vl/qwen3_visual.py
+++ b/lightllm/models/qwen3_vl/qwen3_visual.py
@@ -199,7 +199,7 @@ class Qwen3VisionTransformerPretrainedModel(nn.Module):
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
         return
 
     def concat_img_embed_and_deepstack_features(self, image_embed, deepstack_feature_lists, valid_ids):
@@ -386,7 +386,7 @@ class Qwen3VisionTransformerPretrainedModel(nn.Module):
                 img_tensors.append(pixel_values)
                 img_grids.append(image_grid_thw)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             # must devide merge_length
             cur_num = img_tensors[-1].shape[0] // (self.spatial_merge_size ** 2)

--- a/lightllm/models/qwen_vl/qwen_visual.py
+++ b/lightllm/models/qwen_vl/qwen_visual.py
@@ -427,7 +427,7 @@ class QWenVisionTransformer(nn.Module):
                 t = self.image_transform(image_data)
                 img_tensors.append(t)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(item), item))
+                raise Exception("Unsupported input types: {} for {}".format(type(item), item))
 
             valid_ids.append([valid_id, valid_id + 1])
             valid_id += 1

--- a/lightllm/models/tarsier2/tarsier2_visual.py
+++ b/lightllm/models/tarsier2/tarsier2_visual.py
@@ -187,7 +187,7 @@ class TarsierVisionTransformerPretrainedModel(nn.Module):
                 projector_hidden_act,
             )
         elif projection_head == "auto_map":
-            raise Exception("Unsupport projection_head auto_map")
+            raise Exception("Unsupported projection_head auto_map")
         elif projection_head is None:
             self.multi_modal_projector = lambda x, *args, **kwargs: x
         self.llm_model_type = text_config["model_type"]
@@ -259,7 +259,7 @@ class TarsierVisionTransformerPretrainedModel(nn.Module):
                 img_tensors.append(pixel_values)
                 img_grids.append(image_grid_thw)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             # must devide merge_length
             cur_num = img_tensors[-1].shape[0] // (self.merge_size ** 2)

--- a/lightllm/models/vit/model.py
+++ b/lightllm/models/vit/model.py
@@ -155,7 +155,7 @@ class VisionTransformer:
         elif self.data_type in ["fp32", "float32"]:
             self.data_type = torch.float32
         else:
-            raise ValueError(f"Unsupport datatype {self.data_type}!")
+            raise ValueError(f"Unsupported datatype {self.data_type}!")
 
     @torch.no_grad()
     def forward(self, pixel_values):
@@ -181,7 +181,7 @@ class VisionTransformer:
                 t = self.load_image_func(image_data, max_num=img.extra_params["image_patch_max_num"])
                 img_tensors.append(t)
             else:
-                raise Exception("Unsupport input types: {} for {}".format(type(img), img))
+                raise Exception("Unsupported input types: {} for {}".format(type(img), img))
 
             cur_num = img.token_num
             valid_ids.append([valid_id, valid_id + cur_num])

--- a/lightllm/server/config_server/api_http.py
+++ b/lightllm/server/config_server/api_http.py
@@ -81,7 +81,7 @@ async def visual_websocket_endpoint(websocket: WebSocket):
     client_ip, client_port = websocket.client
     logger.info(f"ws connected from IP: {client_ip}, Port: {client_port}")
     registered_visual_server_obj: VIT_Obj = pickle.loads(await websocket.receive_bytes())
-    logger.info(f"recieved registered_visual_server_obj {registered_visual_server_obj}")
+    logger.info(f"received registered_visual_server_obj {registered_visual_server_obj}")
     with registered_visual_server_obj_lock:
         registered_visual_server_objs[registered_visual_server_obj.node_id] = registered_visual_server_obj
 

--- a/lightllm/utils/envs_utils.py
+++ b/lightllm/utils/envs_utils.py
@@ -59,7 +59,7 @@ def get_llm_data_type() -> torch.dtype:
     elif data_type in ["fp32", "float32"]:
         data_type = torch.float32
     else:
-        raise ValueError(f"Unsupport datatype {data_type}!")
+        raise ValueError(f"Unsupported datatype {data_type}!")
     return data_type
 
 

--- a/lightllm/utils/torch_dtype_utils.py
+++ b/lightllm/utils/torch_dtype_utils.py
@@ -9,4 +9,4 @@ def get_torch_dtype(data_type: str) -> torch.dtype:
     elif data_type in ["fp32", "float32"]:
         return torch.float32
     else:
-        raise ValueError(f"Unsupport datatype {data_type}!")
+        raise ValueError(f"Unsupported datatype {data_type}!")


### PR DESCRIPTION
## What

Small drive-by fix: the error/log messages used **\"Unsupport datatype\"**, **\"Unsupport input types\"**, etc., which read as ungrammatical when surfaced to users. This PR corrects the wording to **\"Unsupported\"** across all sites.

While I was here I also fixed one **\"recieved\" -> \"received\"** typo in [`config_server/api_http.py`](https://github.com/ModelTC/LightLLM/blob/main/lightllm/server/config_server/api_http.py).

## Scope

- 20 occurrences of `Unsupport ` (with trailing space) across 13 files
- 1 occurrence of `recieved`

All changes are **string-only** — there is **no behavior change**. Touched files:

```
lightllm/models/gemma3/gemma3_visual.py
lightllm/models/internvl/internvl_visual.py
lightllm/models/llava/llava_visual.py
lightllm/models/qwen2_5_vl/qwen2_5_visual.py
lightllm/models/qwen2_vl/qwen2_visual.py
lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_audio.py
lightllm/models/qwen3_omni_moe_thinker/qwen3_omni_visual.py
lightllm/models/qwen3_vl/qwen3_visual.py
lightllm/models/qwen_vl/qwen_visual.py
lightllm/models/tarsier2/tarsier2_visual.py
lightllm/models/vit/model.py
lightllm/server/config_server/api_http.py
lightllm/utils/envs_utils.py
lightllm/utils/torch_dtype_utils.py
```

## Why

Error messages are part of the public-facing surface — when a user passes an unsupported image type or dtype, the message they see is the only signal they get. Correct wording makes the diagnosis a little easier and the project look more polished.

## Verification

- All touched files pass `python -m py_compile` (syntax-only check)
- `grep -rn \"Unsupport \" --include='*.py' lightllm/` returns zero matches after the change
- No imports added or removed; no API change