### PR TITLE
refactor(mtp): extract BaseMTPModel mixin shared by existing MTP draft models

### DIFF
--- a/lightllm/models/base_mtp_model.py
+++ b/lightllm/models/base_mtp_model.py
@@ -1,0 +1,36 @@
+from typing import List
+
+from lightllm.common.basemodel.basemodel import TpPartBaseModel
+
+
+class BaseMTPModel:
+    """Shared wiring for MTP draft models: they reuse the main model's req/mem managers and rope
+    caches, and pop the main_model / previous-draft-models kwargs before the base __init__ (#25).
+    Mixed in BEFORE the concrete base model so these overrides win via MRO.
+
+    Also carries the is_mtp_draft_model marker consumed by detection sites (#23)."""
+
+    is_mtp_draft_model = True
+
+    def __init__(self, kvargs: dict):
+        self._pre_init(kvargs)
+        super().__init__(kvargs)
+        return
+
+    def _pre_init(self, kvargs: dict):
+        self.main_model: TpPartBaseModel = kvargs.pop("main_model")
+        self.mtp_previous_draft_models: List[TpPartBaseModel] = kvargs.pop("mtp_previous_draft_models")
+        return
+
+    def _init_custom(self):
+        self._cos_cached = self.main_model._cos_cached
+        self._sin_cached = self.main_model._sin_cached
+        return
+
+    def _init_req_manager(self):
+        self.req_manager = self.main_model.req_manager
+        return
+
+    def _init_mem_manager(self):
+        self.mem_manager = self.main_model.mem_manager
+        return

--- a/lightllm/models/deepseek_mtp/model.py
+++ b/lightllm/models/deepseek_mtp/model.py
@@ -1,37 +1,13 @@
-from typing import List
+from lightllm.models.base_mtp_model import BaseMTPModel
 from lightllm.models.deepseek2.model import Deepseek2TpPartModel
 from lightllm.models.deepseek_mtp.layer_infer.pre_layer_infer import Deepseek3MTPPreLayerInfer
 from lightllm.models.deepseek_mtp.layer_weights.pre_and_post_layer_weight import Deepseek3MTPPreAndPostLayerWeight
-from lightllm.common.basemodel import TpPartBaseModel
 
 
-class Deepseek3MTPModel(Deepseek2TpPartModel):
+class Deepseek3MTPModel(BaseMTPModel, Deepseek2TpPartModel):
 
     pre_and_post_weight_class = Deepseek3MTPPreAndPostLayerWeight
     pre_layer_infer_class = Deepseek3MTPPreLayerInfer
-
-    def __init__(self, kvargs: dict):
-        self._pre_init(kvargs)
-        super().__init__(kvargs)
-        return
-
-    def _pre_init(self, kvargs: dict):
-        self.main_model: TpPartBaseModel = kvargs.pop("main_model")
-        self.mtp_previous_draft_models: List[TpPartBaseModel] = kvargs.pop("mtp_previous_draft_models")
-        return
-
-    def _init_custom(self):
-        self._cos_cached = self.main_model._cos_cached
-        self._sin_cached = self.main_model._sin_cached
-        return
-
-    def _init_req_manager(self):
-        self.req_manager = self.main_model.req_manager
-        return
-
-    def _init_mem_manager(self):
-        self.mem_manager = self.main_model.mem_manager
-        return
 
     def _init_weights(self, start_layer_index=None):
         assert start_layer_index is None

--- a/lightllm/models/glm4_moe_lite_mtp/model.py
+++ b/lightllm/models/glm4_moe_lite_mtp/model.py
@@ -1,35 +1,16 @@
-from typing import List
+from lightllm.models.base_mtp_model import BaseMTPModel
 from lightllm.models.deepseek_mtp.layer_infer.pre_layer_infer import Deepseek3MTPPreLayerInfer
 from lightllm.models.glm4_moe_lite.model import Glm4MoeLiteTpPartModel
 from lightllm.models.glm4_moe_lite_mtp.layer_weights.pre_and_post_layer_weight import (
     Glm4MoeLiteMTPPreAndPostLayerWeight,
 )
-from lightllm.common.basemodel import TpPartBaseModel
 from lightllm.common.basemodel.basemodel import load_hf_weights
 
 
-class Glm4MoeLiteMTPModel(Glm4MoeLiteTpPartModel):
+class Glm4MoeLiteMTPModel(BaseMTPModel, Glm4MoeLiteTpPartModel):
 
     pre_and_post_weight_class = Glm4MoeLiteMTPPreAndPostLayerWeight
     pre_layer_infer_class = Deepseek3MTPPreLayerInfer
-
-    def __init__(self, kvargs: dict):
-        self._pre_init(kvargs)
-        super().__init__(kvargs)
-
-    def _pre_init(self, kvargs: dict):
-        self.main_model: TpPartBaseModel = kvargs.pop("main_model")
-        self.mtp_previous_draft_models: List[TpPartBaseModel] = kvargs.pop("mtp_previous_draft_models")
-
-    def _init_custom(self):
-        self._cos_cached = self.main_model._cos_cached
-        self._sin_cached = self.main_model._sin_cached
-
-    def _init_req_manager(self):
-        self.req_manager = self.main_model.req_manager
-
-    def _init_mem_manager(self):
-        self.mem_manager = self.main_model.mem_manager
 
     def _init_weights(self, start_layer_index=None):
         assert start_layer_index is None

--- a/lightllm/models/mistral_mtp/model.py
+++ b/lightllm/models/mistral_mtp/model.py
@@ -1,14 +1,13 @@
-from typing import List
+from lightllm.models.base_mtp_model import BaseMTPModel
 from lightllm.models.mistral.model import MistralTpPartModel
 from lightllm.models.mistral_mtp.layer_weights.pre_and_post_layer_weight import MistralMTPPreAndPostLayerWeight
 from lightllm.models.mistral_mtp.layer_infer.pre_layer_infer import MistralMTPPreLayerInfer
 from lightllm.models.mistral_mtp.layer_infer.post_layer_infer import MistralMTPPostLayerInfer
 from lightllm.models.mistral_mtp.layer_infer.transformer_layer_infer import MistralMTPTransformerLayerInfer
 from lightllm.models.mistral_mtp.layer_weights.transformer_layer_weight import MistralMTPTransformerLayerWeight
-from lightllm.common.basemodel import TpPartBaseModel
 
 
-class MistralMTPModel(MistralTpPartModel):
+class MistralMTPModel(BaseMTPModel, MistralTpPartModel):
 
     pre_and_post_weight_class = MistralMTPPreAndPostLayerWeight
     pre_layer_infer_class = MistralMTPPreLayerInfer
@@ -18,32 +17,9 @@ class MistralMTPModel(MistralTpPartModel):
 
     post_layer_infer_class = MistralMTPPostLayerInfer
 
-    def __init__(self, kvargs: dict):
-        self._pre_init(kvargs)
-        super().__init__(kvargs)
-        return
-
-    def _pre_init(self, kvargs: dict):
-        self.main_model: TpPartBaseModel = kvargs.pop("main_model")
-        self.mtp_previous_draft_models: List[TpPartBaseModel] = kvargs.pop("mtp_previous_draft_models")
-        return
-
     def _init_some_value(self):
         super()._init_some_value()
         self.layers_num = 1
-        return
-
-    def _init_custom(self):
-        self._cos_cached = self.main_model._cos_cached
-        self._sin_cached = self.main_model._sin_cached
-        return
-
-    def _init_req_manager(self):
-        self.req_manager = self.main_model.req_manager
-        return
-
-    def _init_mem_manager(self):
-        self.mem_manager = self.main_model.mem_manager
         return
 
     def _init_weights(self, start_layer_index=None):

--- a/lightllm/models/qwen3_moe_mtp/model.py
+++ b/lightllm/models/qwen3_moe_mtp/model.py
@@ -1,42 +1,18 @@
-from typing import List
+from lightllm.models.base_mtp_model import BaseMTPModel
 from lightllm.models.qwen3_moe.model import Qwen3MOEModel
 from lightllm.models.qwen3_moe_mtp.layer_weights.pre_and_post_layer_weight import Qwen3MOEMTPPreAndPostLayerWeight
 from lightllm.models.deepseek_mtp.layer_infer.pre_layer_infer import Deepseek3MTPPreLayerInfer
 from lightllm.models.qwen3_moe_mtp.layer_infer.transformer_layer_infer import Qwen3MOEMTPTransformerLayerInfer
 from lightllm.models.qwen3_moe_mtp.layer_weights.transformer_layer_weight import Qwen3MOEMTPTransformerLayerWeight
-from lightllm.common.basemodel import TpPartBaseModel
 
 
-class Qwen3MOEMTPModel(Qwen3MOEModel):
+class Qwen3MOEMTPModel(BaseMTPModel, Qwen3MOEModel):
 
     pre_and_post_weight_class = Qwen3MOEMTPPreAndPostLayerWeight
     pre_layer_infer_class = Deepseek3MTPPreLayerInfer
 
     transformer_weight_class = Qwen3MOEMTPTransformerLayerWeight
     transformer_layer_infer_class = Qwen3MOEMTPTransformerLayerInfer
-
-    def __init__(self, kvargs: dict):
-        self._pre_init(kvargs)
-        super().__init__(kvargs)
-        return
-
-    def _pre_init(self, kvargs: dict):
-        self.main_model: TpPartBaseModel = kvargs.pop("main_model")
-        self.mtp_previous_draft_models: List[TpPartBaseModel] = kvargs.pop("mtp_previous_draft_models")
-        return
-
-    def _init_custom(self):
-        self._cos_cached = self.main_model._cos_cached
-        self._sin_cached = self.main_model._sin_cached
-        return
-
-    def _init_req_manager(self):
-        self.req_manager = self.main_model.req_manager
-        return
-
-    def _init_mem_manager(self):
-        self.mem_manager = self.main_model.mem_manager
-        return
 
     def _init_weights(self, start_layer_index=None):
         assert start_layer_index is None

--- a/unit_tests/models/test_base_mtp_model_mixin.py
+++ b/unit_tests/models/test_base_mtp_model_mixin.py
@@ -1,0 +1,22 @@
+import types
+
+
+def test_mixin_pre_init_pops_and_shares_managers():
+    from lightllm.models.base_mtp_model import BaseMTPModel
+
+    main = types.SimpleNamespace(_cos_cached="cos", _sin_cached="sin", req_manager="rm", mem_manager="mm")
+
+    obj = BaseMTPModel.__new__(BaseMTPModel)
+    kvargs = {"main_model": main, "mtp_previous_draft_models": ["d0"], "other": 1}
+    obj._pre_init(kvargs)
+    assert obj.main_model is main
+    assert obj.mtp_previous_draft_models == ["d0"]
+    assert "main_model" not in kvargs and "mtp_previous_draft_models" not in kvargs
+
+    obj._init_custom()
+    obj._init_req_manager()
+    obj._init_mem_manager()
+    assert obj._cos_cached == "cos" and obj._sin_cached == "sin"
+    assert obj.req_manager == "rm" and obj.mem_manager == "mm"
+
+    assert BaseMTPModel.is_mtp_draft_model is True


### PR DESCRIPTION
## What

Extracts a small `BaseMTPModel` mixin that consolidates the draft-model wiring duplicated across the existing MTP models — `deepseek_mtp`, `mistral_mtp`, `glm4_moe_lite_mtp`, and `qwen3_moe_mtp`.

Each of those draft models repeated the same setup: reuse the main model's req/mem managers and rope caches, pop the `main_model` / `mtp_previous_draft_models` kwargs before the base `__init__`, and mark themselves as draft models. This moves that shared logic into one place.

## Why

A behaviour-preserving cleanup (**+8/−99** across the four models) that removes duplication and gives a single home for the `is_mtp_draft_model` marker. It is a preparatory refactor split out of a larger Qwen3.5 / Qwen3.5-MoE MTP change so the follow-up feature PR stays focused on the new capability.

## Changes

- New `lightllm/models/base_mtp_model.py` — the `BaseMTPModel` mixin, plus a unit test for its wiring.
- `deepseek_mtp` / `mistral_mtp` / `glm4_moe_lite_mtp` / `qwen3_moe_mtp` model classes now mix in `BaseMTPModel` (mixed in before the concrete base model so the shared overrides win via MRO).

## Testing

- `pre-commit` (black 21.12b0 + flake8 6.1.0) clean.
- `unit_tests/models/test_base_mtp_model_mixin.py` covers the mixin's kwargs-popping, manager/rope sharing, and the `is_mtp_draft_model` marker.
