### PR TITLE
feat: enable prefill cudagraph by default

### DIFF
--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -275,10 +275,21 @@ class TpPartBaseModel:
                 self.graph.warmup(self)
 
     def _init_prefill_cuda_graph(self):
+        args = get_env_start_args()
+        enable_prefill_cudagraph = not args.disable_prefill_cudagraph
+        # prefill cudagraph currently only supports llama/qwen-style models. It is incompatible with
+        # ep moe and dp prefill balance, so auto-skip those configs even when not explicitly disabled.
+        if enable_prefill_cudagraph and args.enable_ep_moe:
+            logger.warning("prefill cudagraph does not support ep moe, disabling it.")
+            enable_prefill_cudagraph = False
+        if enable_prefill_cudagraph and args.enable_dp_prefill_balance:
+            logger.warning("prefill cudagraph does not support dp prefill balance, disabling it.")
+            enable_prefill_cudagraph = False
+
         self.prefill_graph = (
-            None
-            if not get_env_start_args().enable_prefill_cudagraph
-            else PrefillCudaGraph(decode_cuda_graph=self.graph, tp_world_size=self.tp_world_size_)
+            PrefillCudaGraph(decode_cuda_graph=self.graph, tp_world_size=self.tp_world_size_)
+            if enable_prefill_cudagraph
+            else None
         )
         if self.prefill_graph is not None:
             if get_env_start_args().enable_prefill_microbatch_overlap:
@@ -598,10 +609,9 @@ class TpPartBaseModel:
 
     @final
     def _context_forward(self, infer_state: InferStateInfo):
-
         input_embs = self.pre_infer.context_forward(infer_state.input_ids, infer_state, self.pre_post_weight)
         if self.args.enable_dp_prefill_balance:
-            assert not self.args.enable_prefill_cudagraph, "not support now"
+            assert self.prefill_graph is None, "not support now"
             infer_state.prepare_prefill_dp_balance()
             input_embs = infer_state._all_to_all_balance_get(data=input_embs)
 
@@ -889,7 +899,7 @@ class TpPartBaseModel:
 
         # 决定是否进行 dp balance 优化，可以提升dp > 1 时的 prefill 效率。
         if get_env_start_args().enable_dp_prefill_balance:
-            assert not self.args.enable_prefill_cudagraph, "not support now"
+            assert self.prefill_graph is None, "not support now"
             infer_state.prepare_prefill_dp_balance()
             infer_state1.prepare_prefill_dp_balance()
             input_embs = infer_state._all_to_all_balance_get(data=input_embs)

--- a/lightllm/common/basemodel/prefill_cuda_graph.py
+++ b/lightllm/common/basemodel/prefill_cuda_graph.py
@@ -161,7 +161,7 @@ class PrefillCudaGraph:
 
     @torch.no_grad()
     def warmup(self, model):
-        logger.info("Begin capture prefill cudagraph, remove the --enable_prefill_cudagraph to disable it.")
+        logger.info("Begin capture prefill cudagraph, use the --disable_prefill_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 
@@ -220,7 +220,7 @@ class PrefillCudaGraph:
 
     @torch.no_grad()
     def warmup_overlap(self, model):
-        logger.info("Begin capture prefill overlap cudagraph, remove the --enable_prefill_cudagraph to disable it.")
+        logger.info("Begin capture prefill overlap cudagraph, use the --disable_prefill_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 

--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -553,10 +553,11 @@ def make_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--disable_cudagraph", action="store_true", help="Disable the cudagraph of the decoding stage")
     parser.add_argument(
-        "--enable_prefill_cudagraph",
+        "--disable_prefill_cudagraph",
         action="store_true",
-        help="Enable the cudagraph of the prefill stage,"
-        " currently only for llama and qwen model, not support ep moe model",
+        help="Disable the cudagraph of the prefill stage. The prefill cudagraph is enabled by default and"
+        " currently only for llama and qwen model; it is automatically skipped for ep moe models and"
+        " dp prefill balance.",
     )
     parser.add_argument(
         "--prefill_cudagraph_max_handle_token",

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -122,7 +122,7 @@ class StartArgs:
     audio_infer_batch_size: Optional[int] = field(default=None)
     enable_monitor_auth: bool = field(default=False)
     disable_cudagraph: bool = field(default=False)
-    enable_prefill_cudagraph: bool = field(default=False)
+    disable_prefill_cudagraph: bool = field(default=False)
     prefill_cudagraph_max_handle_token: int = field(default=8192)
     graph_max_batch_size: int = field(default=256)
     graph_split_batch_size: int = field(default=32)

--- a/skills/test_model/qwen3.5-0.8b-gsm8k-scenarios/SKILL.md
+++ b/skills/test_model/qwen3.5-0.8b-gsm8k-scenarios/SKILL.md
@@ -27,8 +27,8 @@ description: >-
 
 | # | 名称 | `api_server` 相对上一场景的增量 | `lm_eval` |
 |---|------|----------------------------------|-----------|
-| 1 | 基线 | **`--model_dir` / `--tp 2` / `--port`** | 1 次 |
-| 2 | Prefill CUDA Graph | **`--enable_prefill_cudagraph`** | 1 次 |
+| 1 | 基线（关闭 Prefill CUDA Graph） | **`--model_dir` / `--tp 2` / `--port` / `--disable_prefill_cudagraph`** | 1 次 |
+| 2 | Prefill CUDA Graph（默认开启） | 去掉 **`--disable_prefill_cudagraph`**（Prefill CUDA Graph 现为默认行为） | 1 次 |
 | 3 | Linear-Attention 参数 | **`--linear_att_cache_size 10`**、**`--linear_att_hash_page_size 256`**、**`--linear_att_page_block_num 2`**、**`--max_total_token_num 270000`** | 1 次 |
 | 4 | CPU Cache + Linear-Att | 在场景 3 同类参数基础上增加 **`--enable_cpu_cache`**、**`--cpu_cache_storage_size 128`**（**`--max_total_token_num` 仍为 `270000`**） | **2 次** |
 | 5 | Disk Cache | **`LIGHTLLM_DISK_CACHE_PROMPT_LIMIT_LENGTH=128`**；**`--linear_att_cache_size 128`** 等一组参数，及 **`--enable_cpu_cache`**、**`--enable_disk_cache`**、**`--disk_cache_dir`** 等（见下文命令块） | **2 次** |
@@ -122,23 +122,23 @@ lm_eval --model local-completions \
 
 以下命令块仅列出 **`api_server` 参数差异**。实际执行时须在 **`export http_proxy=`、`export https_proxy=`** 之后，按仓库其它 acc 测试惯例自行补全：**`LOADWORKER=18 CUDA_VISIBLE_DEVICES=…`**、**`nohup`**、以及 **`>> "${LOG_DIR}/server.log" 2>&1 &`**。
 
-### 场景 1：基线
-
-```bash
-python -m lightllm.server.api_server \
-  --model_dir "${MODEL_DIR}" \
-  --tp 2 \
-  --port "${PORT}"
-```
-
-### 场景 2：Prefill CUDA Graph
+### 场景 1：基线（关闭 Prefill CUDA Graph）
 
 ```bash
 python -m lightllm.server.api_server \
   --model_dir "${MODEL_DIR}" \
   --tp 2 \
   --port "${PORT}" \
-  --enable_prefill_cudagraph
+  --disable_prefill_cudagraph
+```
+
+### 场景 2：Prefill CUDA Graph（默认开启）
+
+```bash
+python -m lightllm.server.api_server \
+  --model_dir "${MODEL_DIR}" \
+  --tp 2 \
+  --port "${PORT}"
 ```
 
 ### 场景 3：Linear-Attention 参数

--- a/test/acc/test_qwen3.5.sh
+++ b/test/acc/test_qwen3.5.sh
@@ -13,8 +13,7 @@ export no_proxy="localhost,127.0.0.1,0.0.0.0,::1" HF_ALLOW_CODE_EVAL=1 HF_DATASE
 LOADWORKER=18 CUDA_VISIBLE_DEVICES=6,7 python -m lightllm.server.api_server \
 --model_dir /root/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B/snapshots/2fc06364715b967f1860aea9cf38778875588b17 \
 --tp 2 \
---port 8089 \
---enable_prefill_cudagraph
+--port 8089
 
 export no_proxy="localhost,127.0.0.1,0.0.0.0,::1" HF_ALLOW_CODE_EVAL=1 HF_DATASETS_OFFLINE=0 lm_eval --model local-completions --model_args '{"model":"qwen/Qwen3.5-0.8B", "base_url":"http://localhost:8089/v1/completions", "max_length": 16384}' --tasks gsm8k --batch_size 500 --confirm_run_unsafe_code
 


### PR DESCRIPTION
Make prefill cudagraph the default. Replaces `--enable_prefill_cudagraph` with opt-out `--disable_prefill_cudagraph`; auto-skips ep moe and dp prefill balance.