### PR TITLE
perf(qwen3next): fuse the three MoE gate GEMMs into one (decode)

### DIFF
--- a/lightllm/common/basemodel/triton_kernel/fused_moe/moe_silu_and_mul.py
+++ b/lightllm/common/basemodel/triton_kernel/fused_moe/moe_silu_and_mul.py
@@ -122,7 +122,7 @@ def silu_and_mul_fwd(
     alpha=None,
     run_config=None,
 ):
-    assert input.is_contiguous()
+    assert input.stride(-1) == 1
     assert output.is_contiguous()
     assert (limit is None and alpha is None) or (limit is not None and alpha is not None)
 

--- a/lightllm/common/basemodel/triton_kernel/fused_moe/softmax_topk.py
+++ b/lightllm/common/basemodel/triton_kernel/fused_moe/softmax_topk.py
@@ -28,9 +28,9 @@ def softmax_topk_kernel(
     offsets = tl.arange(0, BLOCK_SIZE)
     if NEED_MASK:
         mask = offsets < n_cols
-        values = tl.load(row_input_ptr + offsets, mask=mask, other=-float("inf"))
+        values = tl.load(row_input_ptr + offsets, mask=mask, other=-float("inf")).to(tl.float32)
     else:
-        values = tl.load(row_input_ptr + offsets)
+        values = tl.load(row_input_ptr + offsets).to(tl.float32)
 
     current_max = tl.max(values, axis=0)
     values = values - current_max
@@ -68,9 +68,9 @@ def softmax_topk(gating_output: torch.Tensor, topk: int, renorm: bool = False):
     num_tokens, num_experts = gating_output.shape
     device = gating_output.device
 
-    if gating_output.dtype != torch.float32:
-        gating_output = gating_output.to(torch.float32)
-
+    # NOTE: the kernel reads per-row strides and casts to fp32 internally, so a
+    # non-contiguous / bf16 gating tensor (e.g. a column slice of a fused gate
+    # GEMM output) is consumed directly with no contiguous fp32 copy.
     topk_vals = torch.empty((num_tokens, topk), dtype=torch.float32, device=device)
     topk_idxs = torch.empty((num_tokens, topk), dtype=torch.int32, device=device)
 

--- a/lightllm/common/basemodel/triton_kernel/fused_moe/topk_select.py
+++ b/lightllm/common/basemodel/triton_kernel/fused_moe/topk_select.py
@@ -32,7 +32,11 @@ def fused_topk(
 ):
     assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
 
-    if sgl_ops is None:
+    # sgl topk_softmax requires a contiguous gating tensor; the triton
+    # softmax_topk reads per-row strides and casts internally, so for a strided
+    # gating view (e.g. a column slice of a fused gate GEMM output) it avoids a
+    # contiguous copy and is bit-identical for these shapes.
+    if sgl_ops is None or not gating_output.is_contiguous():
         return softmax_topk(gating_output, topk, renorm=renormalize)
     M, _ = hidden_states.shape
 

--- a/lightllm/models/qwen3next/layer_infer/transformer_layer_infer.py
+++ b/lightllm/models/qwen3next/layer_infer/transformer_layer_infer.py
@@ -135,8 +135,7 @@ class Qwen3NextTransformerLayerInfer(LlamaTransformerLayerInfer):
             ffn1_out = None
             shared_gate = fused_out[:, gate_up_cols + n_experts : gate_up_cols + n_experts + 1].sigmoid_()
             shared_expert_out.mul_(shared_gate)
-            router_logits = self.alloc_tensor((num_tokens, n_experts), hidden_states.dtype)
-            router_logits.copy_(fused_out[:, gate_up_cols : gate_up_cols + n_experts])
+            router_logits = fused_out[:, gate_up_cols : gate_up_cols + n_experts]
         else:
             shared_expert_out = self._compute_shared_expert(input, infer_state, layer_weight)
             router_logits = layer_weight.moe_gate.mm(hidden_states)

--- a/lightllm/models/qwen3next/layer_infer/transformer_layer_infer.py
+++ b/lightllm/models/qwen3next/layer_infer/transformer_layer_infer.py
@@ -16,6 +16,7 @@ from lightllm.models.qwen3next.triton_kernel.fla.ops import chunk_gated_delta_ru
 from lightllm.models.qwen3next.triton_kernel.fla.ops import fused_recurrent_gated_delta_rule
 from lightllm.distributed import all_reduce
 from lightllm.models.llama.triton_kernel.rotary_emb import rotary_emb_fwd
+from lightllm.common.basemodel.triton_kernel.fused_moe.moe_silu_and_mul import silu_and_mul_fwd
 from lightllm.utils.envs_utils import get_env_start_args, get_llm_data_type
 from functools import partial
 
@@ -45,7 +46,6 @@ class Qwen3NextTransformerLayerInfer(LlamaTransformerLayerInfer):
         return
 
     def _init_linear_layer_metadata(self, layer_num, network_config):
-
         # Linear attention specific dimensions
         self.num_v_heads = network_config["linear_num_value_heads"]
         self.num_k_heads = network_config["linear_num_key_heads"]
@@ -121,12 +121,25 @@ class Qwen3NextTransformerLayerInfer(LlamaTransformerLayerInfer):
     def _moe_ffn_tp(
         self, input: torch.Tensor, infer_state: Qwen3NextInferStateInfo, layer_weight: Qwen3NextTransformerLayerWeight
     ):
-
-        shared_expert_out = self._compute_shared_expert(input, infer_state, layer_weight)
-
         hidden_states = input.view(-1, self.embed_dim_)
         num_tokens, hidden_dim = hidden_states.shape
-        router_logits = layer_weight.moe_gate.mm(hidden_states)
+
+        fused_w, fused_splits = layer_weight.get_fused_moe_gate_weight()
+        if fused_w is not None:
+            gate_up_cols, n_experts = fused_splits
+            fused_out = self.alloc_tensor((num_tokens, fused_w.shape[0]), hidden_states.dtype)
+            torch.mm(hidden_states, fused_w.t(), out=fused_out)
+            ffn1_out = self.alloc_tensor((num_tokens, gate_up_cols // 2), hidden_states.dtype)
+            silu_and_mul_fwd(fused_out[:, :gate_up_cols], ffn1_out)
+            shared_expert_out = layer_weight.down_proj.mm(ffn1_out)
+            ffn1_out = None
+            shared_gate = fused_out[:, gate_up_cols + n_experts : gate_up_cols + n_experts + 1].sigmoid_()
+            shared_expert_out.mul_(shared_gate)
+            router_logits = self.alloc_tensor((num_tokens, n_experts), hidden_states.dtype)
+            router_logits.copy_(fused_out[:, gate_up_cols : gate_up_cols + n_experts])
+        else:
+            shared_expert_out = self._compute_shared_expert(input, infer_state, layer_weight)
+            router_logits = layer_weight.moe_gate.mm(hidden_states)
         layer_weight.experts.experts(
             hidden_states,
             router_logits=router_logits,

--- a/lightllm/models/qwen3next/layer_weights/transformer_layer_weight.py
+++ b/lightllm/models/qwen3next/layer_weights/transformer_layer_weight.py
@@ -17,8 +17,43 @@ class Qwen3NextTransformerLayerWeight(Qwen3MOETransformerLayerWeight):
     def __init__(self, layer_num, data_type, network_config, quant_cfg=None):
         num_full_attention_layers = network_config["full_attention_interval"]
         self.is_linear_attention_layer = (layer_num + 1) % num_full_attention_layers != 0
+        self._fused_moe_gate_weight = None
+        self._fused_moe_gate_splits = None
+        self._fused_moe_gate_checked = False
         super().__init__(layer_num, data_type, network_config, quant_cfg)
         return
+
+    def get_fused_moe_gate_weight(self):
+        if self._fused_moe_gate_checked:
+            return self._fused_moe_gate_weight, self._fused_moe_gate_splits
+        if torch.cuda.is_current_stream_capturing():
+            return None, None
+        self._fused_moe_gate_checked = True
+        from lightllm.common.quantization.no_quant import NoQuantization
+
+        gate_up = getattr(self, "gate_up_proj", None)
+        moe_gate = getattr(self, "moe_gate", None)
+        ffn_gate = getattr(self, "ffn_gate", None)
+        if gate_up is None or moe_gate is None or ffn_gate is None:
+            return None, None
+        if get_env_start_args().enable_ep_moe:
+            return None, None
+        if not isinstance(gate_up.quant_method, NoQuantization):
+            return None, None
+        if gate_up.bias is not None or moe_gate.bias is not None or ffn_gate.bias is not None:
+            return None, None
+        w_gu = gate_up.mm_param.weight  # [2*inter_tp, hidden]
+        w_rg = moe_gate.mm_param.weight  # [n_routed_experts, hidden]
+        w_sg = ffn_gate.mm_param.weight  # [1, hidden]
+        if not (w_gu.dtype == w_rg.dtype == w_sg.dtype == self.data_type_):
+            return None, None
+        fused = torch.cat([w_gu, w_rg, w_sg], dim=0)
+        pad = (-fused.shape[0]) % 8
+        if pad:
+            fused = torch.cat([fused, fused.new_zeros((pad, fused.shape[1]))], dim=0)
+        self._fused_moe_gate_weight = fused
+        self._fused_moe_gate_splits = (w_gu.shape[0], w_rg.shape[0])
+        return self._fused_moe_gate_weight, self._fused_moe_gate_splits
 
     def _init_qkv(self):
         in_dim = self.n_embed


### PR DESCRIPTION
## What

Two stacked decode optimizations for Qwen3-Next-architecture MoE layers. In every MoE FFN the **shared-expert `gate_up`** (TP-sharded), the **router `gate`** (replicated), and the **shared-expert `gate_logit`** (replicated) all read the *same* input.

**Commit 1 — fuse the three gate GEMMs into one.** Concatenate their weights lazily into a single GEMM whose output is zero-padded to a multiple of 8 (odd widths force a slow cuBLAS `align1` kernel). `silu_and_mul_fwd` accepts row-strided views, so the `gate_up` slice feeds it directly (no copy); the shared-expert sigmoid gate is applied inline (col 0 of the padded tail), matching `_compute_shared_expert`.

**Commit 2 — drop the per-layer router-logits copy.** `softmax_topk` casts to fp32 inside the kernel and reads per-row strides, and `fused_topk` routes the non-contiguous router slice of the fused output to it (instead of sgl `topk_softmax`, which needs contiguous). The router slice is passed straight to the experts with no contiguous copy. The triton path is bit-identical to sgl for these shapes (ids match, weight maxdiff 0.0).

Files (5): `moe_silu_and_mul.py`, `softmax_topk.py`, `topk_select.py`, `qwen3next/layer_infer/transformer_layer_infer.py`, `qwen3next/layer_weights/transformer_layer_weight.py`.

## Activation guard (no behavior change otherwise)

Lazy, cached per layer. The fused path is taken **only** when: `NoQuantization`, bf16, EP disabled, **not** during stream capture, no bias on the three gates. Otherwise it transparently falls back to the original three-GEMM path.

## Performance verification

**Model:** Qwen3.5-122B-A10B · **TP8** (8×H200) · bf16 · fa3.
**Harness:** static benchmark (no server/scheduler) `test/benchmark/static_inference/test_model.py`.
**Method:** A/B = HEAD (both commits) vs parent `d471c212` (the 5 changed files reverted), identical config, **3 reps**, CUDA graph ON, `input_len=256 / output_len=128`.

### Reproduce

```bash
docker run --rm --gpus all --privileged --ipc=host \
  --ulimit memlock=-1 --ulimit stack=67108864 \
  -v /dev/shm/:/dev/shm/ -v $MODEL_DIR:/model:ro -v $REPO:/lightllm \
  -e CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -e LOADWORKER=18 \
  -e FLASHINFER_DISABLE_VERSION_CHECK=1 -e PYTHONUNBUFFERED=1 \
  ghcr.io/modeltc/lightllm:main \
  bash -lc "cd /lightllm && python -u test/benchmark/static_inference/test_model.py \
    --model_dir /model --tp 8 --data_type bfloat16 \
    --nccl_host 127.0.0.1 --nccl_port 28901 --max_req_total_len 8192 \
    --llm_prefill_att_backend fa3 --llm_decode_att_backend fa3 \
    --input_len 256 --output_len 128"
# BEFORE = `git checkout d471c212 -- <the 5 files>`, re-run, then restore.
# Omit --batch_size to sweep [2,8,16,32,64,128]. isl=256 avoids a bs128×isl512 mrope grid-Y overflow.
```

### Decode throughput (tokens/s, mean ± std over 3 reps, steady-state step)

| batch | before (`d471c212`) | after (HEAD) | Δ |
|------:|-------------------:|-------------:|---:|
|     2 |     222.1 ± 6.5 |    242.3 ± 0.7 | **+9.1 %** |
|     8 |     814.7 ± 3.8 |    873.9 ± 5.5 | **+7.3 %** |
|    16 |   1501.6 ± 22.6 |  1588.4 ± 17.9 | **+5.8 %** |
|    32 |   2617.8 ± 27.4 |  2809.9 ± 32.4 | **+7.3 %** |
|    64 |   4476.6 ± 52.5 |  4676.8 ± 48.9 | **+4.5 %** |
|   128 |   7517.0 ± 68.9 |  7906.2 ± 108.2 | **+5.2 %** |

- **All batches: +4.5–9.1 %, statistically clear** (Δ > 2σ pooled SE).
- **Commit 2 matters most at bs64.** With commit 1 alone bs64 was ~0 (compute-bound: the `router copy_` + sgl topk cost canceled the fusion gain). Dropping the copy (commit 2) recovered it to **+4.5 %** — it added +1.3–4.6 % across the sweep.
- **Prefill: flat** (within noise) — the optimization targets decode.

### Kernel-level (bs64 decode step, `--torch_profile --disable_cudagraph`)

`aten::mm` calls **301 → 205 (−96 = 2 × 48 layers)** — 3 gate GEMMs collapsed to 1 per layer. The strided-view `silu_and_mul` is free (same 96 calls, same time). The router `copy_` (+48 calls/step in commit 1) is gone in commit 2.

## Accuracy verification

GSM8K via `test/acc/test_gsmk.py` (5-shot `/generate`, 300 questions, `max_tokens=4096`, parallel 128), 122B server TP8 `--disable_cudagraph`.

| config | accuracy | invalid |
|---|--:|--:|
| after (HEAD, both commits) | **0.977** | 0.000 |
| before (`d471c212`) | **0.973** | 0.000 |

Δ = +0.4 pp ≈ 1 question out of 300 → **parity, no regression** (even at T=0, batching/scheduling causes ±1–2 Q run-to-run). Consistent with commit 2's bit-identical claim.

## Correctness

Identical behavior on the fallback path (guard returns the original three-GEMM code). The fused path applies the shared-expert sigmoid gate inline to match `_compute_shared_expert`. Activation confirmed empirically: the only code difference between the two sides is this PR, and decode improves at every batch with no accuracy change.
