### PR TITLE
fix: correct fialed->failed typo in Exception message

### DIFF
--- a/format_out/grammer/core.py
+++ b/format_out/grammer/core.py
@@ -278,7 +278,7 @@ class Graph:
                         for j in range(i + 1, len(items)):
                             if items[j].can_accept_input(cur_t):
                                 print("check failed node:", node)
-                                raise Exception("lr1 check fialed")
+                                raise ValueError("lr1 check failed")
 
         return
 


### PR DESCRIPTION
Corrects `fialed` → `failed` typo in an Exception message in `format_out/grammer/core.py` line 281.

User-facing error message fix.

---

fix: fialed->failed (f+i transposition typo)