### PR TITLE
fix: remove duplicate _ACCESS_LOG_STATUS_COLORS assignment

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -117,7 +117,6 @@ app = FastAPI()
 g_objs.app = app
 
 _ACCESS_LOG_STATUS_COLORS = {2: "\033[32m", 3: "\033[36m", 4: "\033[33m", 5: "\033[31m"}
-_ACCESS_LOG_STATUS_COLORS = {2: "\033[32m", 3: "\033[36m", 4: "\033[33m", 5: "\033[31m"}
 _ACCESS_LOG_RESET = "\033[0m"
 
 


### PR DESCRIPTION
## What this PR does

`_ACCESS_LOG_STATUS_COLORS` was assigned twice on consecutive lines in
`lightllm/server/api_http.py`, with byte-identical values. This removes the
redundant duplicate assignment.

## Why

The two assignments are identical, so the second simply overwrites the first
with the same value — almost certainly a copy/paste or merge artifact. Removing
one line has no effect on behavior; it just cleans up the dead assignment.

## Testing

- No behavior change (the removed line is byte-identical to the one kept).
- `python -m py_compile lightllm/server/api_http.py` passes.
- `pre-commit` (black + flake8) passes.
