### PR TITLE
fix: include actual values in truncated batch_max_tokens assert messages

### DIFF
--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -278,18 +278,20 @@ def normal_or_p_d_start(args):
         if args.batch_max_tokens is None:
             args.batch_max_tokens = args.max_req_total_len
         else:
-            assert args.batch_max_tokens >= args.max_req_total_len, f"batch_max_tokens must >= max_req_total_len"
-            f"but got {args.batch_max_tokens}, {args.max_req_total_len}"
+            assert args.batch_max_tokens >= args.max_req_total_len, (
+                f"batch_max_tokens must >= max_req_total_len, "
+                f"but got {args.batch_max_tokens}, {args.max_req_total_len}"
+            )
     else:
         # chunked 模式下
         if args.batch_max_tokens is None:
             args.batch_max_tokens = 16384 // args.dp
         if args.chunked_prefill_size is None:
             args.chunked_prefill_size = args.batch_max_tokens // 2
-        assert (
-            args.batch_max_tokens >= args.chunked_prefill_size
-        ), "chunked prefill mode, batch_max_tokens must >= chunked_prefill_size, "
-        f"but got {args.batch_max_tokens}, {args.chunked_prefill_size}"
+        assert args.batch_max_tokens >= args.chunked_prefill_size, (
+            "chunked prefill mode, batch_max_tokens must >= chunked_prefill_size, "
+            f"but got {args.batch_max_tokens}, {args.chunked_prefill_size}"
+        )
 
     # linear att cache 参数自动设置
     if args.linear_att_cache_size is None:


### PR DESCRIPTION
## What this PR does

Two `assert` statements in `lightllm/server/api_start.py` were meant to include
the offending values in their error message, but the `f"but got ..."` part was
written on a separate line, outside the assert. This PR folds those strings into
the assert messages so the values are actually shown.

## Why

Because the `f"but got {...}"` line sits outside the `assert`, Python evaluates
it as a standalone expression statement and discards it. As a result, when a user
misconfigures `batch_max_tokens`, the `AssertionError` only shows the generic
message and silently drops the actual values, exactly the information needed to
debug the misconfiguration. This affects both the normal-mode and chunked-prefill
assertions.

## Fix

Wrap each assert message in parentheses so the two string literals are combined
via implicit concatenation, keeping the offending values in the message.

## Testing

- No control-flow change, only the assertion message contents are affected.
- Verified via AST that there are no more orphaned string expression statements
  in the file (the two stray `f"but got ..."` statements are gone).
- `python -m py_compile lightllm/server/api_start.py` passes.
- `pre-commit` (black + flake8) passes.