### PR TITLE
feat: gc.freeze hot processes and disable gc during cudagraph capture

### DIFF
--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -24,6 +24,7 @@ from lightllm.common.basemodel.prefill_cuda_graph import PrefillCudaGraph
 from lightllm.common.quantization import Quantcfg
 from lightllm.common.basemodel.triton_kernel.gather_token_id import gather_token, gather_token_prefill_decode_mixed
 from lightllm.utils.log_utils import init_logger
+from lightllm.utils.gc_utils import freeze_gc, gc_frozen_and_disabled
 from lightllm.utils.dist_utils import get_dp_world_size
 from lightllm.utils.envs_utils import get_env_start_args, get_llm_data_type, get_added_mtp_kv_layer_num
 from lightllm.distributed.communication_op import dist_group_manager
@@ -139,11 +140,13 @@ class TpPartBaseModel:
         self._autotune_warmup()
         self._full_att_decode_autotune()
         self._init_padded_req()
-        self._init_cudagraph()
-        self._init_prefill_cuda_graph()
+        with gc_frozen_and_disabled("cudagraph-capture"):
+            self._init_cudagraph()
+            self._init_prefill_cuda_graph()
         self._check_max_len_infer()
         torch.cuda.empty_cache()
         set_model_init_status(True)
+        freeze_gc("model-infer-worker")
         return
 
     def _init_config(self):
@@ -663,7 +666,6 @@ class TpPartBaseModel:
 
     @final
     def _context_forward(self, infer_state: InferStateInfo):
-
         input_embs = self.pre_infer.context_forward(infer_state.input_ids, infer_state, self.pre_post_weight)
         if self.args.enable_dp_prefill_balance:
             assert not self.args.enable_prefill_cudagraph, "not support now"

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -47,6 +47,7 @@ from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
 from lightllm.utils.log_utils import init_logger
+from lightllm.utils.gc_utils import freeze_gc
 from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.envs_utils import get_unique_server_name
@@ -542,4 +543,5 @@ async def startup_event():
     g_objs.set_args(get_env_start_args())
     loop.create_task(g_objs.httpserver_manager.handle_loop())
     logger.info(f"server start up ok, loop use is {asyncio.get_event_loop()}")
+    freeze_gc("httpserver")
     return

--- a/lightllm/server/detokenization/manager.py
+++ b/lightllm/server/detokenization/manager.py
@@ -16,6 +16,7 @@ from ..tokenizer import get_tokenizer
 import pickle
 import time
 from lightllm.utils.log_utils import init_logger
+from lightllm.utils.gc_utils import freeze_gc
 from lightllm.utils.envs_utils import get_unique_server_name
 from lightllm.utils.shm_port_args import get_shm_port_args
 
@@ -181,5 +182,6 @@ def start_detokenization_process(args, pipe_writer):
         pipe_writer.send(str(e))
         raise
     pipe_writer.send("init ok")
+    freeze_gc("detokenization")
     manager.handle_loop()
     return

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -25,6 +25,7 @@ from .dynamic_prompt.radix_cache import RadixCacheReadOnlyClient
 from lightllm.server.multi_level_kv_cache.cpu_cache_client import CpuKvCacheClient
 from lightllm.server.core.objs.shm_objs_io_buffer import ShmObjsIOBuffer
 from lightllm.utils.log_utils import init_logger, log_time_ready
+from lightllm.utils.gc_utils import freeze_gc
 from lightllm.utils.profiler import ProfilerCmd
 from lightllm.server.router.token_load import TokenLoad
 from lightllm.server.metrics.manager import MetricClient
@@ -508,5 +509,6 @@ def start_router_process(args, pipe_writer):
         raise
 
     pipe_writer.send("init ok")
+    freeze_gc("router")
     loop.run_until_complete(router.loop_for_fwd())
     return

--- a/lightllm/utils/gc_utils.py
+++ b/lightllm/utils/gc_utils.py
@@ -1,0 +1,23 @@
+import gc
+from contextlib import contextmanager
+from lightllm.utils.log_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+def freeze_gc(tag: str = "") -> None:
+    gc.collect()
+    gc.freeze()
+    logger.info(f"gc.freeze done ({tag}): frozen={gc.get_freeze_count()}")
+
+
+@contextmanager
+def gc_frozen_and_disabled(tag: str = ""):
+    freeze_gc(tag)
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()


### PR DESCRIPTION
Python 的 gen-2 GC 会周期性全量扫描存活堆，在常驻服务进程里表现为解码时数百毫秒的卡顿。各常驻进程（model-infer worker、router、detokenization、httpserver）初始化完成后 `gc.collect()+gc.freeze()` 把存活对象移入 permanent generation（每进程约 50 万对象），cudagraph capture 期间临时关闭 gc，退出时恢复进入前的状态。

Qwen3.5-27B，TP2 H200，并发 32 压测 300 秒（p50 不变说明单步计算不受影响，收益全部来自消除 GC 卡顿）：

| ITL | baseline | 本 PR | 变化 |
|---|---|---|---|
| p50 | 10.79 ms | 10.78 ms | 持平 |
| mean | 12.39 ms | 11.79 ms | -4.8% |
| p99 | 35.48 ms | 28.92 ms | -18.5% |
| p99.9 | 111.2 ms | 103.3 ms | -7.1% |
| max | 330.9 ms | 242.4 ms | -26.8% |
| 完成请求数 | 8814 | 9152 | +3.8% |

Qwen3.5-4B 单卡同样条件下：max 255→110 ms，p99.9 51.3→47.2 ms，均值不变。模型越大、存活对象越多，收益越明显。

服务正常，`/generate` 和 `/generate_stream` 输出无异常。