### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           tool-cache: true
           android: true


### PR DESCRIPTION
### What
Pin `jlumbroso/free-disk-space@main` → `54081f1…` in `docker-publish.yml` (tag kept in a trailing comment).

### Why
`@main` is a moving reference. This use is in the [docker-publish job](https://github.com/ModelTC/lightllm/blob/5d59e4907dc9b5338426b56723bdee42d8af9309/.github/workflows/docker-publish.yml), which logs in to the container
registry (`GITHUB_TOKEN`) and pushes images. The workflow already SHA-pins `docker/login-action`, so
this just brings `free-disk-space` in line. If the action's `main` were moved (compromise or an
accidental change), the new code would run in the push job — the class of issue behind the 2025
`tj-actions/changed-files` incident.

### Scope / safety
- Behaviour unchanged — the SHA is the current tip of the action's `main`. Signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>
