### PR TITLE
fix: guard empty free_token_index in InferBatch._filter

### DIFF
--- a/lightllm/server/router/model_infer/infer_batch.py
+++ b/lightllm/server/router/model_infer/infer_batch.py
@@ -281,7 +281,12 @@ class InferenceContext:
             req.shm_req.shm_infer_released = True
             self.shm_req_manager.put_back_req_obj(req.shm_req)
 
-        free_token_index = custom_cat(free_token_index)
+        # 线性注意力混合模型下，请求可能在未产生任何 kv (cur_kv_len == 0) 时被 abort，
+        # 此时 free_token_index 为空列表，custom_cat 无法处理空输入。
+        if len(free_token_index) != 0:
+            free_token_index = custom_cat(free_token_index)
+        else:
+            free_token_index = []
         self.req_manager.free(free_req_index, free_token_index)
 
         finished_req_ids_set = set(finished_request_ids)


### PR DESCRIPTION
For linear-attention mixed models (e.g. Qwen3.5), a request aborted
before any kv is generated (cur_kv_len == 0) makes _linear_att_free_req
return without appending anything. custom_cat then crashes with
'IndexError: list index out of range' on the empty list, killing the
infer_loop thread. Skip custom_cat when the list is empty, matching the
existing guard in pause_reqs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018e7Le4MGpdfA1LdPRShk3f