### PR TITLE
fix: guard empty free_token_index in InferBatch._filter

### DIFF
--- a/lightllm/server/router/model_infer/infer_batch.py
+++ b/lightllm/server/router/model_infer/infer_batch.py
@@ -281,7 +281,8 @@ class InferenceContext:
             req.shm_req.shm_infer_released = True
             self.shm_req_manager.put_back_req_obj(req.shm_req)
 
-        free_token_index = custom_cat(free_token_index)
+        if len(free_token_index) != 0:
+            free_token_index = custom_cat(free_token_index)
         self.req_manager.free(free_req_index, free_token_index)
 
         finished_req_ids_set = set(finished_request_ids)

--- a/lightllm/server/router/model_infer/infer_batch.py
+++ b/lightllm/server/router/model_infer/infer_batch.py
@@ -281,7 +281,7 @@ class InferenceContext:
             req.shm_req.shm_infer_released = True
             self.shm_req_manager.put_back_req_obj(req.shm_req)
 
-        if len(free_token_index) != 0:
+        if free_token_index:
             free_token_index = custom_cat(free_token_index)
         self.req_manager.free(free_req_index, free_token_index)
 


### PR DESCRIPTION
线性注意力混合模型（Qwen3.5 等）下，请求可能在还没产生任何 kv（cur_kv_len == 0）时被 abort，此时 `_linear_att_free_req` 直接返回，不会往 `free_token_index` 里 append。`_filter` 中 `custom_cat` 收到空列表，取 `tensors[0]` 抛 `IndexError: list index out of range`，infer_loop 线程直接挂掉。

参照 `pause_reqs` 里已有的写法，列表为空时跳过 `custom_cat`。空列表传给 `req_manager.free` 是安全的（allocator.free 对空输入是 no-op）。