### PR TITLE
feat: interleave CPU KV cache pages across NUMA nodes

### DIFF
--- a/lightllm/utils/envs_utils.py
+++ b/lightllm/utils/envs_utils.py
@@ -239,6 +239,12 @@ def enable_huge_page():
 
 
 @lru_cache(maxsize=None)
+def disable_cpu_cache_numa_interleave() -> bool:
+    """是否禁用 CPU KV cache 共享内存的 NUMA 交错分配策略。"""
+    return enable_env_vars("LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
+
+
+@lru_cache(maxsize=None)
 def get_added_mtp_kv_layer_num() -> int:
     # mtp 模式下需要在mem manger上扩展draft model使用的layer
     added_mtp_layer_num = 0

--- a/lightllm/utils/envs_utils.py
+++ b/lightllm/utils/envs_utils.py
@@ -239,9 +239,9 @@ def enable_huge_page():
 
 
 @lru_cache(maxsize=None)
-def disable_cpu_cache_numa_interleave() -> bool:
-    """是否禁用 CPU KV cache 共享内存的 NUMA 交错分配策略。"""
-    return enable_env_vars("LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
+def enable_cpu_cache_numa_interleave() -> bool:
+    """是否启用 CPU KV cache 共享内存的 NUMA 交错分配策略。"""
+    return enable_env_vars("LIGHTLLM_ENABLE_NUMA_INTERLEAVE")
 
 
 @lru_cache(maxsize=None)

--- a/lightllm/utils/kv_cache_utils.py
+++ b/lightllm/utils/kv_cache_utils.py
@@ -170,6 +170,87 @@ class CpuKVCacheMeta:
         ) // self.data_type.itemsize
 
 
+def _get_default_hugepage_size() -> int:
+    try:
+        with open("/proc/meminfo", "r") as f:
+            for line in f:
+                if line.startswith("Hugepagesize:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        kb = int(parts[1])
+                        return kb * 1024
+    except Exception:
+        pass
+    return 2 * 1024 * 1024
+
+
+def _get_online_numa_nodes() -> List[int]:
+    for path in ("/sys/devices/system/node/has_memory", "/sys/devices/system/node/online"):
+        try:
+            with open(path, "r") as f:
+                online = f.read().strip()
+            nodes: List[int] = []
+            for part in online.split(","):
+                if "-" in part:
+                    start, end = part.split("-")
+                    nodes.extend(range(int(start), int(end) + 1))
+                else:
+                    nodes.append(int(part))
+            return nodes
+        except Exception:
+            continue
+    return [0]
+
+
+def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
+    MPOL_INTERLEAVE = 3
+    SYS_MBIND = {"x86_64": 237, "aarch64": 235}.get(os.uname().machine)
+
+    if SYS_MBIND is None:
+        logger.warning(f"unsupported architecture {os.uname().machine}, skip cpu cache numa interleave")
+        return False
+
+    if enable_huge_page():
+        huge_sz = _get_default_hugepage_size()
+        size = triton.cdiv(size, huge_sz) * huge_sz
+
+    def _mbind(mode, mask):
+        nodemask = ctypes.c_ulong(mask)
+        libc.syscall.restype = ctypes.c_long
+        return libc.syscall(
+            ctypes.c_long(SYS_MBIND),
+            ctypes.c_void_p(addr),
+            ctypes.c_ulong(size),
+            ctypes.c_int(mode),
+            ctypes.byref(nodemask),
+            ctypes.c_ulong(ctypes.sizeof(nodemask) * 8 + 1),
+            ctypes.c_uint(0),
+        )
+
+    if os.getenv("LIGHTLLM_DISABLE_NUMA_INTERLEAVE", "0") == "1":
+        logger.info("cpu cache numa interleave disabled by LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
+        return False
+    nodes = _get_online_numa_nodes()
+    if len(nodes) <= 1:
+        return False
+    if max(nodes) >= 64:
+        logger.warning(f"more than 64 numa nodes ({nodes}), skip cpu cache numa interleave")
+        return False
+    try:
+        ret = _mbind(MPOL_INTERLEAVE, sum(1 << n for n in nodes))
+        if ret != 0:
+            logger.warning(
+                f"mbind MPOL_INTERLEAVE failed (errno={ctypes.get_errno()}), "
+                f"cpu kv cache pages will use default first-touch numa policy"
+            )
+            return False
+        logger.info(f"cpu kv cache pages interleaved across numa nodes {nodes}")
+        return True
+    except Exception as e:
+        logger.warning(f"cpu cache numa interleave skipped: {e}")
+        return False
+
+
 @lru_cache(maxsize=None)
 def create_shm_kv_cache_ptr(key: int, size: int) -> int:
     libc = ctypes.CDLL("/usr/lib/x86_64-linux-gnu/libc.so.6", use_errno=True)
@@ -180,20 +261,6 @@ def create_shm_kv_cache_ptr(key: int, size: int) -> int:
 
     requested_size = size
     use_hugetlb = enable_huge_page()
-
-    # 计算大页大小（默认从 /proc/meminfo 读取 Hugepagesize）
-    def _get_default_hugepage_size() -> int:
-        try:
-            with open("/proc/meminfo", "r") as f:
-                for line in f:
-                    if line.startswith("Hugepagesize:"):
-                        parts = line.split()
-                        if len(parts) >= 2:
-                            kb = int(parts[1])
-                            return kb * 1024
-        except Exception:
-            pass
-        return 2 * 1024 * 1024  # fallback 2MB
 
     shmflg = 0o666 | 0o1000  # 权限和 IPC_CREAT 标志
     if use_hugetlb:
@@ -233,6 +300,8 @@ def create_shm_kv_cache_ptr(key: int, size: int) -> int:
     if shm_addr == ctypes.c_void_p(-1).value:
         raise Exception("Error attaching shared memory")
     logger.info(f"Shared cpu kv cache tensor memory at address: {shm_addr}")
+
+    interleave_pages_across_numa_nodes(libc, shm_addr, size_to_alloc)
 
     # Best-effort memory prefaulting in background to speed up subsequent cudaHostRegister
     def _pre_warm_memory():
@@ -327,4 +396,6 @@ def attach_shm_kv_cache_ptr(key: int, size: int) -> int:
         raise Exception(f"Error attaching shared memory (errno={err})")
 
     logger.info(f"Attached to SHM key={key}, shmid={shmid}, addr={shm_addr}")
+
+    interleave_pages_across_numa_nodes(libc, shm_addr, size)
     return shm_addr

--- a/lightllm/utils/kv_cache_utils.py
+++ b/lightllm/utils/kv_cache_utils.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from lightllm.utils.envs_utils import (
     get_env_start_args,
     enable_huge_page,
+    disable_cpu_cache_numa_interleave,
     get_llm_data_type,
     get_added_mtp_kv_layer_num,
 )
@@ -170,87 +171,6 @@ class CpuKVCacheMeta:
         ) // self.data_type.itemsize
 
 
-def _get_default_hugepage_size() -> int:
-    try:
-        with open("/proc/meminfo", "r") as f:
-            for line in f:
-                if line.startswith("Hugepagesize:"):
-                    parts = line.split()
-                    if len(parts) >= 2:
-                        kb = int(parts[1])
-                        return kb * 1024
-    except Exception:
-        pass
-    return 2 * 1024 * 1024
-
-
-def _get_online_numa_nodes() -> List[int]:
-    for path in ("/sys/devices/system/node/has_memory", "/sys/devices/system/node/online"):
-        try:
-            with open(path, "r") as f:
-                online = f.read().strip()
-            nodes: List[int] = []
-            for part in online.split(","):
-                if "-" in part:
-                    start, end = part.split("-")
-                    nodes.extend(range(int(start), int(end) + 1))
-                else:
-                    nodes.append(int(part))
-            return nodes
-        except Exception:
-            continue
-    return [0]
-
-
-def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
-    MPOL_INTERLEAVE = 3
-    SYS_MBIND = {"x86_64": 237, "aarch64": 235}.get(os.uname().machine)
-
-    if SYS_MBIND is None:
-        logger.warning(f"unsupported architecture {os.uname().machine}, skip cpu cache numa interleave")
-        return False
-
-    if enable_huge_page():
-        huge_sz = _get_default_hugepage_size()
-        size = triton.cdiv(size, huge_sz) * huge_sz
-
-    def _mbind(mode, mask):
-        nodemask = ctypes.c_ulong(mask)
-        libc.syscall.restype = ctypes.c_long
-        return libc.syscall(
-            ctypes.c_long(SYS_MBIND),
-            ctypes.c_void_p(addr),
-            ctypes.c_ulong(size),
-            ctypes.c_int(mode),
-            ctypes.byref(nodemask),
-            ctypes.c_ulong(ctypes.sizeof(nodemask) * 8 + 1),
-            ctypes.c_uint(0),
-        )
-
-    if os.getenv("LIGHTLLM_DISABLE_NUMA_INTERLEAVE", "0") == "1":
-        logger.info("cpu cache numa interleave disabled by LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
-        return False
-    nodes = _get_online_numa_nodes()
-    if len(nodes) <= 1:
-        return False
-    if max(nodes) >= 64:
-        logger.warning(f"more than 64 numa nodes ({nodes}), skip cpu cache numa interleave")
-        return False
-    try:
-        ret = _mbind(MPOL_INTERLEAVE, sum(1 << n for n in nodes))
-        if ret != 0:
-            logger.warning(
-                f"mbind MPOL_INTERLEAVE failed (errno={ctypes.get_errno()}), "
-                f"cpu kv cache pages will use default first-touch numa policy"
-            )
-            return False
-        logger.info(f"cpu kv cache pages interleaved across numa nodes {nodes}")
-        return True
-    except Exception as e:
-        logger.warning(f"cpu cache numa interleave skipped: {e}")
-        return False
-
-
 @lru_cache(maxsize=None)
 def create_shm_kv_cache_ptr(key: int, size: int) -> int:
     libc = ctypes.CDLL("/usr/lib/x86_64-linux-gnu/libc.so.6", use_errno=True)
@@ -399,3 +319,107 @@ def attach_shm_kv_cache_ptr(key: int, size: int) -> int:
 
     interleave_pages_across_numa_nodes(libc, shm_addr, size)
     return shm_addr
+
+
+def _get_default_hugepage_size() -> int:
+    try:
+        with open("/proc/meminfo", "r") as f:
+            for line in f:
+                if line.startswith("Hugepagesize:"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        kb = int(parts[1])
+                        return kb * 1024
+    except Exception:
+        pass
+    return 2 * 1024 * 1024
+
+
+def _get_online_numa_nodes() -> List[int]:
+    for path in ("/sys/devices/system/node/has_memory", "/sys/devices/system/node/online"):
+        try:
+            with open(path, "r") as f:
+                online = f.read().strip()
+            nodes: List[int] = []
+            for part in online.split(","):
+                if "-" in part:
+                    start, end = part.split("-")
+                    nodes.extend(range(int(start), int(end) + 1))
+                else:
+                    nodes.append(int(part))
+            return nodes
+        except Exception:
+            continue
+    return [0]
+
+
+def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
+    """为 CPU KV cache 的共享内存映射设置 NUMA 交错分配策略。
+
+    CPU KV cache 使用 SysV SHM 在多个进程间共享。默认的 first-touch 策略会把物理页分配到
+    首次触页线程所在的 NUMA 节点；在多 Socket 机器上，后台 prefault 线程的调度位置可能导致
+    大量 cache 页集中到单个内存控制器，限制多个 GPU 并发 load/offload 的主机内存带宽。
+
+    本函数通过 ``mbind(MPOL_INTERLEAVE)`` 将映射范围内尚未分配的物理页按页偏移交错放置到
+    可用 NUMA 节点。调用方应在首次触页前设置策略：creator 在启动 prefault 线程前调用；
+    HugeTLB 的共享策略不会可靠地传播到其他进程的 VMA，因此 attacher 也需要在访问映射前调用。
+
+    调用未设置 ``MPOL_MF_MOVE``，所以只影响后续缺页分配，不迁移已经分配的物理页。禁用开关、
+    单 NUMA、不支持的架构或 syscall 失败都会安全回退到原有 first-touch 行为。
+
+    Args:
+        libc: 使用 ``use_errno=True`` 加载的 libc 对象，用于发起 raw ``mbind`` syscall。
+        addr: ``shmat`` 返回的、按页对齐的映射起始虚拟地址。
+        size: 需要设置策略的映射长度；HugeTLB 模式下会向上对齐到默认大页大小。
+
+    Returns:
+        策略成功安装时返回 ``True``；跳过或安装失败时返回 ``False``。
+    """
+    MPOL_INTERLEAVE = 3
+    SYS_MBIND = {"x86_64": 237, "aarch64": 235}.get(os.uname().machine)
+
+    if SYS_MBIND is None:
+        logger.warning(f"unsupported architecture {os.uname().machine}, skip cpu cache numa interleave")
+        return False
+
+    if enable_huge_page():
+        huge_sz = _get_default_hugepage_size()
+        size = triton.cdiv(size, huge_sz) * huge_sz
+
+    def _mbind(mode, mask):
+        nodemask = ctypes.c_ulong(mask)
+        libc.syscall.restype = ctypes.c_long
+        return libc.syscall(
+            ctypes.c_long(SYS_MBIND),
+            ctypes.c_void_p(addr),
+            ctypes.c_ulong(size),
+            ctypes.c_int(mode),
+            ctypes.byref(nodemask),
+            # Raw syscall ABI decrements maxnode before copying the bitmap.
+            # Passing mask width + 1 preserves every bit while copying exactly one c_ulong.
+            ctypes.c_ulong(ctypes.sizeof(nodemask) * 8 + 1),
+            ctypes.c_uint(0),
+        )
+
+    if disable_cpu_cache_numa_interleave():
+        logger.info("cpu cache numa interleave disabled by LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
+        return False
+    nodes = _get_online_numa_nodes()
+    if len(nodes) <= 1:
+        return False
+    if max(nodes) >= 64:
+        logger.warning(f"more than 64 numa nodes ({nodes}), skip cpu cache numa interleave")
+        return False
+    try:
+        ret = _mbind(MPOL_INTERLEAVE, sum(1 << n for n in nodes))
+        if ret != 0:
+            logger.warning(
+                f"mbind MPOL_INTERLEAVE failed (errno={ctypes.get_errno()}), "
+                f"cpu kv cache pages will use default first-touch numa policy"
+            )
+            return False
+        logger.info(f"cpu kv cache pages interleaved across numa nodes {nodes}")
+        return True
+    except Exception as e:
+        logger.warning(f"cpu cache numa interleave skipped: {e}")
+        return False

--- a/lightllm/utils/kv_cache_utils.py
+++ b/lightllm/utils/kv_cache_utils.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from lightllm.utils.envs_utils import (
     get_env_start_args,
     enable_huge_page,
-    disable_cpu_cache_numa_interleave,
+    enable_cpu_cache_numa_interleave,
     get_llm_data_type,
     get_added_mtp_kv_layer_num,
 )
@@ -364,8 +364,9 @@ def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
     可用 NUMA 节点。调用方应在首次触页前设置策略：creator 在启动 prefault 线程前调用；
     HugeTLB 的共享策略不会可靠地传播到其他进程的 VMA，因此 attacher 也需要在访问映射前调用。
 
-    调用未设置 ``MPOL_MF_MOVE``，所以只影响后续缺页分配，不迁移已经分配的物理页。禁用开关、
-    单 NUMA、不支持的架构或 syscall 失败都会安全回退到原有 first-touch 行为。
+    调用未设置 ``MPOL_MF_MOVE``，所以只影响后续缺页分配，不迁移已经分配的物理页。该功能默认
+    关闭，只有设置 ``LIGHTLLM_ENABLE_NUMA_INTERLEAVE`` 后才会启用；未启用、单 NUMA、不支持的
+    架构或 syscall 失败都会安全回退到原有 first-touch 行为。
 
     Args:
         libc: 使用 ``use_errno=True`` 加载的 libc 对象，用于发起 raw ``mbind`` syscall。
@@ -377,6 +378,9 @@ def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
     """
     MPOL_INTERLEAVE = 3
     SYS_MBIND = {"x86_64": 237, "aarch64": 235}.get(os.uname().machine)
+
+    if not enable_cpu_cache_numa_interleave():
+        return False
 
     if SYS_MBIND is None:
         logger.warning(f"unsupported architecture {os.uname().machine}, skip cpu cache numa interleave")
@@ -401,9 +405,6 @@ def interleave_pages_across_numa_nodes(libc, addr: int, size: int) -> bool:
             ctypes.c_uint(0),
         )
 
-    if disable_cpu_cache_numa_interleave():
-        logger.info("cpu cache numa interleave disabled by LIGHTLLM_DISABLE_NUMA_INTERLEAVE")
-        return False
     nodes = _get_online_numa_nodes()
     if len(nodes) <= 1:
         return False


### PR DESCRIPTION
CPU KV cache 的共享内存由 prefault 线程首次触碰，物理页落点取决于当时的线程调度。多 Socket 上连续 cache 分块可能集中到单个内存控制器，GPU 并发 load/offload 的带宽和运行间波动都会受影响。

这个改动提供可选的 NUMA interleave 策略：在 prefault 前对 SHM VMA 设置 `MPOL_INTERLEAVE`，并对每个 attacher 的 VMA 设置相同策略。策略只影响后续缺页，不迁移已分配页。

该功能现在默认关闭，未配置时继续使用 first-touch。需要显式设置：

```bash
export LIGHTLLM_ENABLE_NUMA_INTERLEAVE=1
```

才会调用 `mbind`。单 NUMA、不支持的架构或 `mbind` 失败时也会安全回退到 first-touch。旧的 `LIGHTLLM_DISABLE_NUMA_INTERLEAVE` 已移除，环境变量统一在 `envs_utils.py` 管理。

## E2E

在一台双 NUMA、8×RTX 5090 机器上（GPU 0-3 在 N0，4-7 在 N1），用 InternLM2.5-7B-chat BF16、TP8 对比：

- A：first-touch
- B：interleave
- benchmark commit：`4c42ffd2`（当时的开关语义为 A 设置 `LIGHTLLM_DISABLE_NUMA_INTERLEAVE=1`、B 默认启用；当前版本的等价配置为 A 默认、B 设置 `LIGHTLLM_ENABLE_NUMA_INTERLEAVE=1`）
- image：`lightllm:v1.5.3-main-9565289-cu130`
- CPU KV cache：64 GiB，page size 128；并发 16
- 每个请求 7,909 prompt tokens，其中 7,808 tokens 从 CPU cache 恢复，输出 16 tokens

每个服务实例先分别 seed 两套前缀，再按 set-1→set-2→set-1→set-2 发送 64 个 timed requests。变体外层做 3 组 ABBA，共 12 次独立服务启动、768 个 timed requests。

| ABBA 组 | A throughput | B throughput | B vs A | A mean TTFT | B mean TTFT | TTFT 改善 |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 15.300 req/s | 15.381 req/s | +0.52% | 648.45 ms | 642.38 ms | 0.94% |
| 2 | 14.664 req/s | 15.415 req/s | +5.13% | 680.58 ms | 646.06 ms | 5.07% |
| 3 | 14.894 req/s | 15.473 req/s | +3.89% | 669.65 ms | 636.26 ms | 4.99% |

6 次 A/B run 的中位数：

| metric | A | B | 改善 |
|---|---:|---:|---:|
| Request throughput | 14.918 req/s | 15.399 req/s | +3.22% |
| Cached-token throughput | 116.48k tok/s | 120.24k tok/s | +3.22% |
| Mean TTFT | 667.08 ms | 644.36 ms | 3.41% |
| Mean request latency | 738.44 ms | 713.97 ms | 3.31% |

三组 throughput 配对结果都为正，平均改善 3.18%；n=3 的 95% CI 为 [-2.74%, 9.10%]，因此这是方向一致的 E2E 收益，但样本量不足以声称统计显著。

768/768 个 timed requests 都命中服务端 CPU cache，没有错误。6 次 B run 的 64 GiB 映射均精确落在 N0/N1 各 8,388,608 页；A 的 N0 占比在 33.4% 到 76.9% 之间。试跑期间发现 `--ipc=host` 会遗留 SysV SHM，相关数据已排除；正式结果在每次启动前检查可用内存、每次退出后回收对应 SHM。

## DMA microbenchmark

同一台机器上，用普通 4K 页测 pinned SHM 的 GPU DMA，每组 3 轮 ABBA：

| GPU 组合 | 聚合带宽 | first-touch 中位数 | interleave 中位数 | 变化 |
|---|---|---:|---:|---:|
| 0,1,2,3,6,7（跨 NUMA） | GPU→CPU offload | 144.40 GB/s | 170.26 GB/s | +17.9% |
| 0,1,2,3,6,7（跨 NUMA） | CPU→GPU load | 259.33 GB/s | 325.44 GB/s | +25.5% |
| 0,1,2,3（均在 NUMA0） | GPU→CPU offload | 114.65 GB/s | 143.28 GB/s | +25.0% |
| 0,1,2,3（均在 NUMA0） | CPU→GPU load | 163.22 GB/s | 224.43 GB/s | +37.5% |

interleave 的 `numa_maps` 每次都是精确 50/50；first-touch 的运行间波动明显更大。E2E 收益小于 DMA 微基准，符合 CPU cache 恢复只是请求链路一部分的预期。

## 最新精度回归

在当前 head `227e76de` 上完成以下全量回归，`LIGHTLLM_ENABLE_NUMA_INTERLEAVE` 均未设置，用于验证默认 first-touch 路径。

### Qwen3.5-0.8B CPU cache + linear attention

GSM8K 全量 1,319 条，在同一服务生命周期连续执行两次：

| 运行 | CPU cache | strict exact match | flexible exact match |
|---|---|---:|---:|
| Run 1 | 1,319/1,319 未命中（写入 cache） | 433/1,319 = 0.328279 | 436/1,319 = 0.330553 |
| Run 2 | 1,319/1,319 命中 | 433/1,319 = 0.328279 | 439/1,319 = 0.332828 |

两轮 strict accuracy 完全一致，CPU cache 分配、prefault、attach、pinned-memory 注册及全命中路径均正常，没有 cache 异常。

### Qwen3-VL-8B-Instruct

MMMU validation 全量 900 条：

| 模式 | mmmu_acc | 结果 |
|---|---:|---|
| direct，TP2 | 439/900 = 0.48778 | PASS |
| ViT separation（config + visual_only + normal TP2） | 438/900 = 0.48667 | PASS |

两个模式 900 条请求均完成并保存逐样本结果。3/900 条原始响应不同，只有 1 条影响正确性；ViT separation 的 438/900 与上一轮回归完全一致，属于单样本运行间波动，没有 visual proxy、AFS、请求或评测错误。

## 权限与降级行为

另一个双 NUMA、8×H200 的容器环境启用了 Docker seccomp，且没有 `CAP_SYS_NICE`。在显式启用 interleave 的诊断中，`mbind`、`set_mempolicy` 和 `get_mempolicy` 均返回 `EPERM`；cpuset 允许的内存节点为 `0-1`，因此失败来自容器安全策略，而不是无效 nodemask。

当前默认关闭配置不会调用 `mbind`，上述最新回归日志中没有 `mbind`/`EPERM`。显式启用但受限时会记录 warning 并安全回退到 first-touch；若需要在该容器覆盖成功路径，应增加 `CAP_SYS_NICE` 或使用允许 NUMA policy syscall 的定制 seccomp profile。

pre-commit 的 Black、Flake8 检查通过。