### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/format.py
+++ b/format.py
@@ -1,6 +1,6 @@
-import os
 import glob
+import subprocess
 
 for filename in glob.glob('./**/*.py', recursive=True):
     print(filename)
-    os.system(f"autopep8 --max-line-length 140 --in-place --aggressive --aggressive {filename}")
+    subprocess.run(['autopep8', '--max-line-length', '140', '--in-place', '--aggressive', '--aggressive', filename])


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `Medium` | **File**: `format.py:L4`

The `format.py` script uses `os.system(f"autopep8 ... {filename}")` where `filename` is derived from `glob.glob`. While `glob.glob` is generally safe, using `os.system` with f-strings is a dangerous anti-pattern. If the repository is ever cloned or placed in a directory with maliciously named Python files (e.g., a file named `foo.py; rm -rf /`), it could lead to arbitrary command execution.

## Solution

Replace `os.system` with `subprocess.run` using a list of arguments to avoid shell interpretation. For example: `subprocess.run(['autopep8', '--max-line-length', '140', '--in-place', '--aggressive', '--aggressive', filename])`.

## Changes

- `format.py` (modified)