### PR TITLE
fix: improve Qwen3.5 MTP accept rate

### DIFF
--- a/lightllm/models/qwen3_5_mtp/layer_infer/pre_layer_infer.py
+++ b/lightllm/models/qwen3_5_mtp/layer_infer/pre_layer_infer.py
@@ -23,6 +23,7 @@ class Qwen3_5MTPPreLayerInfer(Qwen3VLMultimodalPreLayerInfer):
             input_embdings.shape[0] == tgt_embdings.shape[0]
         ), f"shape {input_embdings.shape} != shape {tgt_embdings.shape}"
 
+        layer_weight.main_norm_weight_(input=tgt_embdings, eps=self.eps_, out=tgt_embdings)
         layer_weight.enorm_weight_(input=input_embdings, eps=self.eps_, out=input_embdings)
         layer_weight.hnorm_weight_(input=tgt_embdings, eps=self.eps_, out=tgt_embdings)
         cat_embdings = torch.cat((input_embdings, tgt_embdings), dim=-1)

--- a/lightllm/models/qwen3_5_mtp/layer_weights/pre_and_post_layer_weight.py
+++ b/lightllm/models/qwen3_5_mtp/layer_weights/pre_and_post_layer_weight.py
@@ -42,4 +42,5 @@ class Qwen3_5MTPPreAndPostLayerWeight(PreAndPostLayerWeight):
         # Shared with the main Qwen3.5 model, injected by the model class (not loaded here).
         self.wte_weight_: EmbeddingWeight = None
         self.lm_head_weight_: LMHeadWeight = None
+        self.main_norm_weight_: NoTpGEMMANormWeight = None
         return

--- a/lightllm/models/qwen3_5_mtp/model.py
+++ b/lightllm/models/qwen3_5_mtp/model.py
@@ -69,6 +69,7 @@ class Qwen3_5MTPModel(Qwen3_5TpPartModel):
         # Shared with the main Qwen3.5 model (mtp_use_dedicated_embeddings: false).
         self.pre_post_weight.wte_weight_ = self.main_model.pre_post_weight.wte_weight_
         self.pre_post_weight.lm_head_weight_ = self.main_model.pre_post_weight.lm_head_weight_
+        self.pre_post_weight.main_norm_weight_ = self.main_model.pre_post_weight.final_norm_weight_
         return
 
     def _init_infer_layer(self, start_layer_index=None):


### PR DESCRIPTION
Qwen3.5 MTP draft 需要使用 final norm 后的 hidden，当前实现直接传入 raw hidden，导致接受长度偏低。

本 PR 像共享 embedding/lm_head 一样把 main final norm 共享给 draft，并在 draft 输入融合前执行 norm；改动仅限 `qwen3_5_mtp`。

验证：H200、Qwen3.5-0.8B、TP=1、`eagle_with_att`、`mtp_step=3`，8 个固定请求各生成 256 tokens；按相同口径汇总的 accept length 从 `1.804` 提升到 `2.738`（+51.7%），输出与 producer-side post-norm 版本逐项一致。相关 MTP CUDA 单测 2/2 通过，Black、Flake8 和 `py_compile` 通过。