### PR TITLE
docs: remove non-existent --pd_decode_rpyc_port option and fix benchmark_client.py path

### DIFF
--- a/docs/CN/source/tutorial/api_server_args.rst
+++ b/docs/CN/source/tutorial/api_server_args.rst
@@ -87,10 +87,6 @@ PD 分离模式参数
     推理进度健康检查：当仍有在途请求，且整个 PD Master 连续 ``HEALTH_TIMEOUT`` 秒
     没有任何请求成功返回 token 时，接口将返回 HTTP 503。
 
-.. option:: --pd_decode_rpyc_port
-
-    PD 模式下解码节点用于 kv move manager rpyc 服务器的端口，默认为 ``42000``
-
 .. option:: --config_server_host
 
     配置服务器模式下的主机地址

--- a/docs/CN/source/tutorial/deepseek_deployment.rst
+++ b/docs/CN/source/tutorial/deepseek_deployment.rst
@@ -356,7 +356,7 @@ PD (Prefill-Decode) 分离模式将预填充和解码阶段分离部署，可以
 
     # DeepSeek-R1 性能测试
     cd test
-    python benchmark_client.py \
+    python benchmark/service/benchmark_client.py \
     --num_clients 100 \
     --input_num 2000 \
     --tokenizer_path /path/DeepSeek-R1/ \

--- a/docs/EN/source/tutorial/api_server_args.rst
+++ b/docs/EN/source/tutorial/api_server_args.rst
@@ -90,10 +90,6 @@ PD disaggregation Mode Parameters
     the endpoints return HTTP 503 if no request on the PD Master successfully returns a token for
     ``HEALTH_TIMEOUT`` consecutive seconds.
 
-.. option:: --pd_decode_rpyc_port
-
-    Port used by decode nodes for kv move manager rpyc server in PD mode, default is ``42000``
-
 .. option:: --config_server_host
 
     Host address in configuration server mode

--- a/docs/EN/source/tutorial/deepseek_deployment.rst
+++ b/docs/EN/source/tutorial/deepseek_deployment.rst
@@ -354,7 +354,7 @@ Supports multiple PD Master nodes, providing better load balancing and high avai
 
     # DeepSeek-R1 Performance Testing
     cd test
-    python benchmark_client.py \
+    python benchmark/service/benchmark_client.py \
     --num_clients 100 \
     --input_num 2000 \
     --tokenizer_path /path/DeepSeek-R1/ \


### PR DESCRIPTION
Two doc issues, each fixed in both the EN and CN docs:

**1. `--pd_decode_rpyc_port` does not exist.** `api_server_args` documents an `.. option:: --pd_decode_rpyc_port`, but that flag is defined nowhere in the CLI — `lightllm/server/api_cli.py` (`add_cli_args`) and the `StartArgs` dataclass have no such field; the only rpyc-port flag is `--visual_rpyc_port`. Passing `--pd_decode_rpyc_port` to `api_server` fails with `error: unrecognized arguments`. Removed the stale option block.

**2. Wrong `benchmark_client.py` path.** The DeepSeek performance-test snippet runs:
```bash
cd test
python benchmark_client.py ...
```
but that file lives at `test/benchmark/service/benchmark_client.py`, so it fails with `can't open file 'benchmark_client.py': No such file or directory`. Fixed to `python benchmark/service/benchmark_client.py` (matching `docs/*/getting_started/benchmark.rst`, which already uses the correct `test/benchmark/service/benchmark_client.py`).

Docs-only.