### PR TITLE
fix(multinode): use JSON instead of pickle for node-IP exchange to prevent RCE

### DIFF
--- a/lightllm/utils/multinode_utils.py
+++ b/lightllm/utils/multinode_utils.py
@@ -19,7 +19,10 @@ def send_and_receive_node_ip(args):
                 comm_socket = context.socket(zmq.PULL)
                 comm_socket.bind(f"tcp://*:{args.multinode_httpmanager_port + i + 100}")
                 logger.info(f"binding port {args.multinode_httpmanager_port + i + 100}")
-                args.child_ips.append(comm_socket.recv_pyobj())
+                # Use JSON instead of pickle: the payload is only the child IP
+                # string, and recv_pyobj() -> pickle.loads() on a socket bound to
+                # all interfaces would allow unauthenticated RCE (cf. CVE-2025-32444).
+                args.child_ips.append(comm_socket.recv_json())
                 comm_socket.close()
             logger.info(f"Received child IPs: {args.child_ips}")
         else:
@@ -28,5 +31,5 @@ def send_and_receive_node_ip(args):
             comm_socket = context.socket(zmq.PUSH)
             comm_socket.connect(f"tcp://{args.nccl_host}:{args.multinode_httpmanager_port + args.node_rank + 100}")
             logger.info(f"connecting to {args.nccl_host}:{args.multinode_httpmanager_port + args.node_rank + 100}")
-            comm_socket.send_pyobj(local_ip)
+            comm_socket.send_json(local_ip)
             comm_socket.close()


### PR DESCRIPTION
## Summary

`send_and_receive_node_ip()` binds a ZMQ `PULL` socket on `tcp://*:{port}` (all interfaces, `0.0.0.0`) on the head node during multinode startup and reads peer data with `recv_pyobj()`, which is `pickle.loads()` on the raw socket bytes. Any host that can reach the port can send a crafted pickle payload and achieve arbitrary code execution on the head node — the same class of issue as CVE-2025-32444 in vLLM. Closes #1413.

## Fix

The only value exchanged is the child node's IP string, which is fully JSON-serializable, so this switches the `send_pyobj`/`recv_pyobj` pair to `send_json`/`recv_json`. This removes the pickle deserialization sink at the network boundary with no behavioral change (a string round-trips identically through JSON).

```diff
-                args.child_ips.append(comm_socket.recv_pyobj())
+                args.child_ips.append(comm_socket.recv_json())
...
-            comm_socket.send_pyobj(local_ip)
+            comm_socket.send_json(local_ip)
```

## Note on the diff base

My fork's `main` trailed upstream and I don't hold the `workflow` OAuth scope, so I couldn't rebase this branch directly onto the current `main` tip (upstream has since refactored the surrounding `base_port` lines in this same function). GitHub may therefore flag a small merge conflict confined to the two adjacent lines — it resolves trivially by keeping upstream's `base_port` lines and applying only the `recv_json`/`send_json` change. Happy to hand the patch over in whatever form is easiest, or a maintainer can cherry-pick the two-line change onto tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
