### PR TITLE
fix(api): harden OpenAI streaming/non-streaming error handling

### DIFF
--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -376,6 +376,9 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
     except ClientDisconnected as e:
         logger.warning(str(e))
         return Response(status_code=499)
+    except Exception as e:
+        logger.error("An error occurred: %s", str(e), exc_info=True)
+        return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
     return resp
 
 
@@ -396,6 +399,9 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
     except ClientDisconnected as e:
         logger.warning(str(e))
         return Response(status_code=499)
+    except Exception as e:
+        logger.error("An error occurred: %s", str(e), exc_info=True)
+        return create_error_response(HTTPStatus.EXPECTATION_FAILED, str(e))
     return resp
 
 

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -30,7 +30,7 @@ from .httpserver.manager import HttpServerManager
 from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
-from lightllm.utils.error_utils import ClientDisconnected
+from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
 
 from lightllm.utils.log_utils import init_logger
 from lightllm.server.metrics.manager import MetricClient
@@ -60,6 +60,23 @@ from .api_models import (
 logger = init_logger(__name__)
 
 
+def _record_request_failure_metric():
+    try:
+        from .api_http import g_objs
+
+        if g_objs.metric_client is not None:
+            g_objs.metric_client.counter_inc("lightllm_request_failure")
+    except Exception:
+        logger.warning("Failed to record lightllm_request_failure metric", exc_info=True)
+
+
+def _stream_error_chunk(message: str, err_type: str, code: Optional[int] = None):
+    error = {"message": message, "type": err_type}
+    if code is not None:
+        error["code"] = code
+    return f"data: {json.dumps({'error': error}, ensure_ascii=False)}\n\n"
+
+
 async def _safe_stream_wrapper(stream_generator):
     """Wrap a streaming generator to catch ValueError (e.g. input too long) and yield an SSE error
     event instead of letting the exception propagate to Starlette which prints a long traceback."""
@@ -67,12 +84,22 @@ async def _safe_stream_wrapper(stream_generator):
         async for item in stream_generator:
             yield item
     except ValueError as e:
-        error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
-        yield f"data: {error_data}\n\n"
+        _record_request_failure_metric()
+        yield _stream_error_chunk(str(e), "invalid_request_error")
+    except ServerBusyError as e:
+        logger.error("%s", str(e), exc_info=True)
+        _record_request_failure_metric()
+        yield _stream_error_chunk(str(e), "ServerBusyError", e.status_code)
     except ClientDisconnected as e:
         logger.warning(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.
         return
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.error("An error occurred in streaming response: %s", str(e), exc_info=True)
+        _record_request_failure_metric()
+        yield _stream_error_chunk(str(e), "InternalServerError")
 
 
 def _serialize_sse_chunk(chunk, choice_nulls=(), response_nulls=()):

--- a/unit_tests/server/test_openai_stream_error_handling.py
+++ b/unit_tests/server/test_openai_stream_error_handling.py
@@ -1,0 +1,98 @@
+import asyncio
+
+import ujson as json
+
+from lightllm.server import api_http
+from lightllm.server.api_openai import _safe_stream_wrapper
+from lightllm.utils.error_utils import ServerBusyError
+
+
+class FakeMetricClient:
+    def __init__(self):
+        self.counters = []
+
+    def counter_inc(self, name):
+        self.counters.append(name)
+
+
+def _decode_sse_payload(chunk):
+    if isinstance(chunk, bytes):
+        chunk = chunk.decode("utf-8")
+    assert chunk.startswith("data: ")
+    return json.loads(chunk.removeprefix("data: ").strip())
+
+
+def _collect(gen):
+    async def drain():
+        return [c async for c in gen]
+
+    return asyncio.run(drain())
+
+
+def test_safe_stream_wrapper_converts_unexpected_exception_to_sse_error(monkeypatch):
+    metric_client = FakeMetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+
+    async def failing_stream():
+        if False:
+            yield b""
+        raise RuntimeError("backend failed")
+
+    chunks = _collect(_safe_stream_wrapper(failing_stream()))
+
+    assert len(chunks) == 1
+    payload = _decode_sse_payload(chunks[0])
+    assert payload["error"]["message"] == "backend failed"
+    assert payload["error"]["type"] == "InternalServerError"
+    assert metric_client.counters == ["lightllm_request_failure"]
+
+
+def test_safe_stream_wrapper_maps_server_busy_error(monkeypatch):
+    metric_client = FakeMetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+
+    async def busy_stream():
+        if False:
+            yield b""
+        raise ServerBusyError("server overloaded")
+
+    chunks = _collect(_safe_stream_wrapper(busy_stream()))
+
+    assert len(chunks) == 1
+    payload = _decode_sse_payload(chunks[0])
+    assert payload["error"]["type"] == "ServerBusyError"
+    assert payload["error"]["code"] == 503
+    assert metric_client.counters == ["lightllm_request_failure"]
+
+
+def test_safe_stream_wrapper_keeps_value_error_as_invalid_request(monkeypatch):
+    metric_client = FakeMetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+
+    async def bad_stream():
+        if False:
+            yield b""
+        raise ValueError("input too long")
+
+    chunks = _collect(_safe_stream_wrapper(bad_stream()))
+
+    payload = _decode_sse_payload(chunks[0])
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert metric_client.counters == ["lightllm_request_failure"]
+
+
+def test_safe_stream_wrapper_swallows_client_disconnect(monkeypatch):
+    from lightllm.utils.error_utils import ClientDisconnected
+
+    metric_client = FakeMetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+
+    async def gone_stream():
+        if False:
+            yield b""
+        raise ClientDisconnected("client gone")
+
+    chunks = _collect(_safe_stream_wrapper(gone_stream()))
+
+    assert chunks == []
+    assert metric_client.counters == []


### PR DESCRIPTION
## 背景

OpenAI 兼容接口（`/v1/chat/completions`、`/v1/completions`）在两个层面缺少对未预期异常的兜底：

1. **非流式 handler**（`chat_completions` / `completions`）：只有 `ValueError` / `ServerBusyError` / `ClientDisconnected` 的捕获，其它异常会冒泡到 Starlette，返回 500 + 长堆栈，且没有结构化错误体。而同文件里的 `/generate`、`/generate_stream` handler 已经有 `except Exception` 兜底，行为不一致。
2. **流式 `_safe_stream_wrapper`**：只捕获 `ValueError` 和 `ClientDisconnected`。后端推理过程中抛出的 `ServerBusyError` 或其它异常同样会冒泡到 Starlette，客户端只能收到被中断的 SSE 流，拿不到结构化错误；且这条失败路径不会累计 `lightllm_request_failure` 指标（非流式路径经由 `create_error_response` 是会累计的）。

## 改动

- `lightllm/server/api_http.py`：给 `chat_completions` 和 `completions` 各加一个 `except Exception` 兜底，返回结构化的 `EXPECTATION_FAILED (417)` 响应，并 `logger.error(..., exc_info=True)` 记录堆栈。与 `/generate` handler 对齐。
- `lightllm/server/api_openai.py`：扩展 `_safe_stream_wrapper`：
  - `ServerBusyError` → 输出 `ServerBusyError` SSE 错误块（带 `code=503`），并累计失败指标；
  - `asyncio.CancelledError` → 直接 `raise`，不吞掉取消；
  - 其它 `Exception` → 输出 `InternalServerError` SSE 错误块，并累计失败指标；
  - `ValueError` 分支同样补上失败指标累计，行为与 `create_error_response` 一致。
  - 抽出 `_record_request_failure_metric` / `_stream_error_chunk` 两个小辅助函数复用。
- `unit_tests/server/test_openai_stream_error_handling.py`：新增单测，覆盖 `Exception` / `ServerBusyError` / `ValueError` / `ClientDisconnected` 四种情况下的 SSE 输出与指标累计。沿用仓库现有的 `asyncio.run` 风格，未引入 `pytest-asyncio` 依赖。

## 兼容性

- 纯错误路径增强，正常请求行为不变。
- 失败指标 `lightllm_request_failure` 此前在流式失败时漏统计，本 PR 补齐，监控数值会因此上升（更准确）。

## 测试

`pytest unit_tests/server/test_openai_stream_error_handling.py` 4 passed；`pre-commit run`（black 21.12b0 + flake8）通过。