### PR TITLE
fix(api): raise litellm floor to 1.84.8 for tool_choice="none"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,5 +97,5 @@ cupy-cuda13x==14.0.1
 nixl==1.2.0
 xformers==0.0.35
 redis==7.3.0
-litellm>=1.52.0,<1.85
+litellm>=1.84.8,<1.85
 torch_memory_saver==0.0.9.post1


### PR DESCRIPTION
## 背景

代码中多处依赖 `tool_choice="none"` 语义（`api_openai.py` 的 chat/completions 路径，以及 `api_anthropic.py` 里经由 litellm anthropic 适配器的路径）。litellm 1.84.8 之前的版本对这些路径下的 `tool_choice="none"` 处理不正确。

## 改动

`requirements.txt`：`litellm>=1.52.0,<1.85` → `litellm>=1.84.8,<1.85`。

仅抬高下限，上限 `<1.85` 不变。