### PR TITLE
fix: bump tiktoken to 0.8.0 for litellm 1.84.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ wheel==0.40.0
 zstandard==0.23.0
 safetensors==0.4.5
 Pillow==10.4.0
-tiktoken==0.7.0
+tiktoken==0.8.0
 matplotlib==3.10.0
 psutil==5.9.4
 prometheus_client==0.20.0


### PR DESCRIPTION
## 问题

`#1427` 把 litellm 下界提到了 1.84.8，但 `requirements.txt` 里的 `tiktoken==0.7.0` 没跟着改。

litellm 1.84.8 要求 `tiktoken>=0.8.0,<1.0`，与钉死的 0.7.0 直接冲突，导致从干净索引安装 `requirements.txt` 时 pip 报 `ResolutionImpossible`，镜像构建失败。

## 修复

```
-tiktoken==0.7.0
+tiktoken==0.8.0
```

提到 0.8.0，刚好满足 litellm 1.84.8 的下界，最小改动。