### PR TITLE
fix(cli): remove keep-alive settings via env vars

### DIFF
--- a/docs/CN/source/tutorial/api_server_args.rst
+++ b/docs/CN/source/tutorial/api_server_args.rst
@@ -43,7 +43,7 @@ APIServer 参数详解
 .. option:: --hypercorn_config
 
     Hypercorn TOML 配置文件路径，仅支持 TOML 格式。示例文件见 ``test/hypercorn_config.toml``。
-    默认为 ``None``。LightLLM 显式设置的监听地址、HTTP worker 数和 keep-alive 超时会覆盖配置文件中的对应值。
+    默认为 ``None``。LightLLM 显式设置的监听地址和 HTTP worker 数会覆盖配置文件中的对应值。
 
 .. option:: --zmq_mode
 

--- a/docs/EN/source/tutorial/api_server_args.rst
+++ b/docs/EN/source/tutorial/api_server_args.rst
@@ -43,9 +43,8 @@ Basic Configuration Parameters
 .. option:: --hypercorn_config
 
     Path to a Hypercorn TOML configuration file. Only TOML configuration files are supported.
-    See ``test/hypercorn_config.toml`` for an example. Default: ``None``. The bind address, HTTP worker
-    count, and keep-alive timeout explicitly set by LightLLM override the corresponding values in the
-    configuration file.
+    See ``test/hypercorn_config.toml`` for an example. Default: ``None``. The bind address and HTTP worker
+    count explicitly set by LightLLM override the corresponding values in the configuration file.
 
 .. option:: --zmq_mode
 

--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -8,7 +8,6 @@ from .metrics.manager import start_metric_manager
 from .embed_cache.manager import start_cache_manager
 from lightllm.utils.log_utils import init_logger
 from lightllm.utils.envs_utils import set_env_start_args, set_unique_server_name, get_unique_server_name
-from lightllm.utils.envs_utils import get_lightllm_gunicorn_keep_alive
 from lightllm.utils.shm_port_args import get_shm_port_args
 from lightllm.utils.net_utils import validate_ports
 from .detokenization.manager import start_detokenization_process
@@ -393,13 +392,17 @@ def _launch_subprocesses(args: StartArgs):
     return process_manager
 
 
+def _hypercorn_config_args(args: StartArgs):
+    return ["--config", args.hypercorn_config] if args.hypercorn_config is not None else []
+
+
 def normal_or_p_d_start(args: StartArgs):
     process_manager = _launch_subprocesses(args)
 
     # 启动 Hypercorn
     command = [
         "hypercorn",
-        *(["--config", args.hypercorn_config] if args.hypercorn_config is not None else []),
+        *_hypercorn_config_args(args),
         "--workers",
         f"{args.httpserver_workers}",
         "--bind",
@@ -411,8 +414,6 @@ def normal_or_p_d_start(args: StartArgs):
         "--error-logfile",
         "-",
         "lightllm.server.api_http:app",
-        "--keep-alive",
-        f"{get_lightllm_gunicorn_keep_alive()}",
     ]
 
     # 启动子进程
@@ -464,7 +465,7 @@ def pd_master_start(args: StartArgs):
 
     command = [
         "hypercorn",
-        *(["--config", args.hypercorn_config] if args.hypercorn_config is not None else []),
+        *_hypercorn_config_args(args),
         "--workers",
         "1",
         "--bind",
@@ -476,8 +477,6 @@ def pd_master_start(args: StartArgs):
         "--error-logfile",
         "-",
         "lightllm.server.api_http:app",
-        "--keep-alive",
-        f"{get_lightllm_gunicorn_keep_alive()}",
     ]
 
     http_server_process = subprocess.Popen(command)
@@ -554,7 +553,7 @@ def config_server_start(args):
 
     command = [
         "hypercorn",
-        *(["--config", args.hypercorn_config] if args.hypercorn_config is not None else []),
+        *_hypercorn_config_args(args),
         "--workers",
         "1",
         "--bind",
@@ -566,8 +565,6 @@ def config_server_start(args):
         "--error-logfile",
         "-",
         "lightllm.server.config_server.api_http:app",
-        "--keep-alive",
-        f"{get_lightllm_gunicorn_keep_alive()}",
     ]
 
     http_server_process = subprocess.Popen(command)

--- a/lightllm/utils/envs_utils.py
+++ b/lightllm/utils/envs_utils.py
@@ -87,10 +87,6 @@ def get_deepep_num_max_dispatch_tokens_per_rank_decode():
     return int(os.getenv("NUM_MAX_DISPATCH_TOKENS_PER_RANK_DECODE", 256))
 
 
-def get_lightllm_gunicorn_keep_alive():
-    return int(os.getenv("LIGHTLMM_GUNICORN_KEEP_ALIVE", 10))
-
-
 @lru_cache(maxsize=None)
 def get_lightllm_websocket_max_message_size():
     """

--- a/test/hypercorn_config.toml
+++ b/test/hypercorn_config.toml
@@ -1,9 +1,3 @@
-# Hypercorn options that are not exposed directly by LightLLM's CLI.
 h2_max_concurrent_streams = 2147483647
 keep_alive_max_requests = 2147483647
-
-# LightLLM controls these options via --host/--port, --httpserver_workers,
-# and LIGHTLMM_GUNICORN_KEEP_ALIVE respectively:
-# bind = "0.0.0.0:9080"
-# workers = 8
-# keep_alive_timeout = 2147483647
+keep_alive_timeout = 2147483647


### PR DESCRIPTION
`LIGHTLMM_GUNICORN_KEEP_ALIVE` 把 `LLM` 错拼成了 `LMM`，而且没有相关的 issue，可以考虑抛弃掉。

而且如果用户真的对配置 keep alive 的 timeout 有需求，实际上也会对于 `keep_alive_max_requests` 有需求，可以大致猜测该环境变量没有外部用户在使用。

后续迁移可以指引大家使用 `--hypercorn_config`，并增加如下配置：
~~~toml
h2_max_concurrent_streams = 2147483647
keep_alive_max_requests = 2147483647
keep_alive_timeout = 2147483647
~~~

