### PR TITLE
fix: refresh health heartbeat on request admission to avoid 503 during long prefill after idle

### DIFF
--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -337,7 +337,10 @@ class HttpServerManager(HttpRlManagerHelper, object):
         )
 
         async with self._run_reqs_count_lock:
-            self.run_reqs_count_mark.set_value(self.run_reqs_count_mark.get_value() + 1)
+            prev = self.run_reqs_count_mark.get_value()
+            self.run_reqs_count_mark.set_value(prev + 1)
+            if prev == 0:
+                self.latest_success_infer_time_mark.set_value(int(time.time()))
 
         try:
             # RL：进入 generation admission。若当前处于 pause_generation / abort，

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -129,7 +129,10 @@ class HttpServerManagerForPDMaster:
         multimodal_params: MultimodalParams,
         request: Request,
     ):
+        was_idle = self.running_request_count == 0
         self.running_request_count += 1
+        if was_idle:
+            self.latest_success_infer_time = time.time()
         try:
             async with aclosing(self._generate(prompt, sampling_params, multimodal_params, request)) as generator:
                 async for result in generator:


### PR DESCRIPTION
## 问题

`/health` 在「服务长时间闲置后，突然来了一个长请求」的场景下，会在首个输出 token 产生之前持续返回 503。

## 根因

健康判定逻辑（`lightllm/utils/health_check.py`）：

- 健康 = 距上次成功推理 ≤ `HEALTH_TIMEOUT`（默认 200s）**或**（无在途请求 且 shm 空闲）
- 心跳 `latest_success_infer_time_mark` **只在吐出 token 时刷新**

闲置期间 `last_success` 早已过期，靠「无在途请求」分支兜底；一旦有请求准入，该分支瞬间失效，而 grace 窗口又已耗尽 —— 出现断层。于是长 prefill 的整段都判为不健康，会被 LB/探针误踢下线。

## 修复

在请求准入时（`generate()` 入口，自增 `run_reqs_count` 的同一把锁内）刷新一次心跳时间戳，重置 grace 窗口，让 prefill 阶段被覆盖。

- `lightllm/server/httpserver/manager.py`：准入刷新 `latest_success_infer_time_mark`
- `lightllm/server/httpserver_for_pd_master/manager.py`：准入刷新 `latest_success_infer_time`（对称逻辑，同样的漏洞）

## 取舍

准入即刷新会带来一个已知放宽：当请求源源不断地准入时，即便后端不再吐 token，心跳也会被持续刷新，`/health` 不会变 503（即「busy 但卡死」的检测能力在该持续流量下被削弱）。本 PR 优先保证闲置后长 prefill 不被误判下线这一线上实际问题；卡死检测可后续结合 token 产出单独加强。