### PR TITLE
fix: bump Jinja2 to 3.1.6 to satisfy litellm>=1.84.8 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ h11==0.14.0
 humanfriendly==10.0
 humanize==4.7.0
 idna==3.4
-Jinja2==3.1.2
+Jinja2==3.1.6
 jmespath==1.0.1
 jsonpatch==1.32
 jsonpointer==2.0


### PR DESCRIPTION
## 问题

`2c27b814`（bump tiktoken to 0.8.0 for litellm 1.84.8）合入后，Docker 构建 CI（`build` job）失败：

```
ERROR: Cannot install -r /lightllm/requirements.txt (line 100) and Jinja2==3.1.2
because these package versions have conflicting dependencies.

The user requested Jinja2==3.1.2
litellm 1.84.8 / 1.84.9 / 1.84.10 depends on jinja2<4.0 and >=3.1.6
ERROR: ResolutionImpossible
```

## 原因

`requirements.txt` 仍钉 `Jinja2==3.1.2`，而新抬地板的 `litellm>=1.84.8,<1.85` 要求 `jinja2>=3.1.6,<4.0`，pip 解析不出一致解。

## 修复

`Jinja2==3.1.2` → `Jinja2==3.1.6`（litellm 要求的下界，同时此版本也修了 CVE-2025-27516）。

## 验证

用与 CI 一致的索引（`pypi.org/simple` + `download.pytorch.org/whl/cu130`）跑 `pip install -r requirements.txt --dry-run`：改前在 Jinja2/litellm 处 `ResolutionImpossible`；改后整棵依赖树解析通过（`Would install ... litellm-1.84.10 Jinja2-3.1.6 ...`），无其它冲突。