### PR TITLE
fix: chunk prompt logprobs all-gather

### DIFF
--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -359,13 +359,13 @@ class TpPartBaseModel:
             return self._decode(model_input)
 
     @torch.no_grad()
-    def compute_prompt_logits(
+    def gather_prompt_logits_chunk(
         self,
         prompt_shard_logits: torch.Tensor,
         microbatch_index: int = 0,
     ) -> torch.Tensor:
         """Gather one bounded token chunk of TP-sharded prompt logits."""
-        return self.post_infer.prompt_logits_forward(
+        return self.post_infer.gather_prompt_logits_chunk(
             prompt_shard_logits,
             self.pre_post_weight,
             dist_group_manager.get_group(microbatch_index),

--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -361,12 +361,12 @@ class TpPartBaseModel:
     @torch.no_grad()
     def compute_prompt_logits(
         self,
-        prompt_hidden_states: torch.Tensor,
+        prompt_shard_logits: torch.Tensor,
         microbatch_index: int = 0,
     ) -> torch.Tensor:
-        """Compute one bounded chunk of prompt logits after model forward."""
+        """Gather one bounded token chunk of TP-sharded prompt logits."""
         return self.post_infer.prompt_logits_forward(
-            prompt_hidden_states,
+            prompt_shard_logits,
             self.pre_post_weight,
             dist_group_manager.get_group(microbatch_index),
         )
@@ -545,10 +545,9 @@ class TpPartBaseModel:
         new_model_output = copy.copy(padded_model_output)
         # logits 始终只对应每个请求最后一个位置，移除 padding 的 req 对应的行。
         new_model_output.logits = new_model_output.logits[0:origin_batch_size]
-        # prompt_logics 保存本次 prefill 所有 token 位置的 hidden states，
-        # 按实际处理的 token 数量裁剪掉 padding 部分（仅 return_all_prompt_logics 模式下非空）。
+        # prompt_logics is [local_vocab, prompt_tokens]; trim token padding.
         if new_model_output.prompt_logics is not None:
-            new_model_output.prompt_logics = new_model_output.prompt_logics[0:origin_handle_token_num]
+            new_model_output.prompt_logics = new_model_output.prompt_logics[:, 0:origin_handle_token_num]
 
         # 特殊模型，特殊模式的特殊变量的特殊 unpad
         if new_model_output.mtp_main_output_hiddens is not None:

--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -358,6 +358,19 @@ class TpPartBaseModel:
         else:
             return self._decode(model_input)
 
+    @torch.no_grad()
+    def compute_prompt_logits(
+        self,
+        prompt_hidden_states: torch.Tensor,
+        microbatch_index: int = 0,
+    ) -> torch.Tensor:
+        """Compute one bounded chunk of prompt logits after model forward."""
+        return self.post_infer.prompt_logits_forward(
+            prompt_hidden_states,
+            self.pre_post_weight,
+            dist_group_manager.get_group(microbatch_index),
+        )
+
     def _create_inferstate(self, model_input: ModelInput, microbatch_index: int = 0):
         infer_state = self.infer_state_class()
         infer_state.input_ids = model_input.input_ids
@@ -532,7 +545,7 @@ class TpPartBaseModel:
         new_model_output = copy.copy(padded_model_output)
         # logits 始终只对应每个请求最后一个位置，移除 padding 的 req 对应的行。
         new_model_output.logits = new_model_output.logits[0:origin_batch_size]
-        # prompt_logics 保存整个 prefill 阶段所有 token 位置的 logits，
+        # prompt_logics 保存本次 prefill 所有 token 位置的 hidden states，
         # 按实际处理的 token 数量裁剪掉 padding 部分（仅 return_all_prompt_logics 模式下非空）。
         if new_model_output.prompt_logics is not None:
             new_model_output.prompt_logics = new_model_output.prompt_logics[0:origin_handle_token_num]

--- a/lightllm/common/basemodel/batch_objs.py
+++ b/lightllm/common/basemodel/batch_objs.py
@@ -113,12 +113,13 @@ class ModelOutput:
     mtp_main_output_hiddens: Optional[torch.Tensor] = None
 
     # prompt_logics 用于在开启 return_all_prompt_logics 模式（如 enable_prompt_logprobs）时，
-    # 保存整个 prefill 阶段每一个 token 位置对应的 logits（而非仅最后一个位置的 logits）。
-    # 此时 logits 依然只保存每个请求最后一个位置的 logits，prompt_logics 为可选项，仅在
-    # 需要返回 prompt logprobs 信息时才会非空。
+    # 保存本次 prefill 每一个 token 位置对应的 hidden state。backend 会按 token
+    # 分块计算 logits，避免完整 [prompt_tokens, vocab_size] 张量常驻 GPU。
     prompt_logics: Optional[torch.Tensor] = None
 
     def to_no_ref_tensor(self):
         self.logits = tensor_to_no_ref_tensor(self.logits)
         if self.mtp_main_output_hiddens is not None:
             self.mtp_main_output_hiddens = tensor_to_no_ref_tensor(self.mtp_main_output_hiddens)
+        if self.prompt_logics is not None:
+            self.prompt_logics = tensor_to_no_ref_tensor(self.prompt_logics)

--- a/lightllm/common/basemodel/batch_objs.py
+++ b/lightllm/common/basemodel/batch_objs.py
@@ -113,8 +113,8 @@ class ModelOutput:
     mtp_main_output_hiddens: Optional[torch.Tensor] = None
 
     # prompt_logics 用于在开启 return_all_prompt_logics 模式（如 enable_prompt_logprobs）时，
-    # 保存本次 prefill 每一个 token 位置对应的 hidden state。backend 会按 token
-    # 分块计算 logits，避免完整 [prompt_tokens, vocab_size] 张量常驻 GPU。
+    # 保存 [local_vocab_size, prompt_tokens] 的 TP-sharded logits。backend 按 token
+    # 分块 all-gather，避免完整 [prompt_tokens, vocab_size] 张量常驻 GPU。
     prompt_logics: Optional[torch.Tensor] = None
 
     def to_no_ref_tensor(self):

--- a/lightllm/common/basemodel/infer_struct.py
+++ b/lightllm/common/basemodel/infer_struct.py
@@ -56,8 +56,8 @@ class InferStateInfo:
 
         self.is_token_healing: bool = False
         self.return_all_prompt_logics: bool = False
-        # 在开启 return_all_prompt_logics 模式时，保存整个 prefill 阶段每一个
-        # token 位置的 logits，供后续回传 prompt logprobs 信息使用。
+        # 在开启 return_all_prompt_logics 模式时，保存本次 prefill 每一个
+        # token 位置的 hidden state，供 backend 分块计算 prompt logprobs。
         # 仅在 prefill 阶段且需要返回 prompt logprobs 时才会被填充。
         self.prompt_logics: Optional[torch.Tensor] = None
         self.multimodal_params: dict = None

--- a/lightllm/common/basemodel/infer_struct.py
+++ b/lightllm/common/basemodel/infer_struct.py
@@ -56,8 +56,8 @@ class InferStateInfo:
 
         self.is_token_healing: bool = False
         self.return_all_prompt_logics: bool = False
-        # 在开启 return_all_prompt_logics 模式时，保存本次 prefill 每一个
-        # token 位置的 hidden state，供 backend 分块计算 prompt logprobs。
+        # 在开启 return_all_prompt_logics 模式时，保存本次 prefill 的
+        # [local_vocab_size, prompt_tokens] sharded logits，供 backend 分块 all-gather。
         # 仅在 prefill 阶段且需要返回 prompt logprobs 时才会被填充。
         self.prompt_logics: Optional[torch.Tensor] = None
         self.multimodal_params: dict = None

--- a/lightllm/models/gemma4/layer_infer/post_layer_infer.py
+++ b/lightllm/models/gemma4/layer_infer/post_layer_infer.py
@@ -12,11 +12,8 @@ class Gemma4PostLayerInfer(LlamaPostLayerInfer):
         super().__init__(network_config)
         self.final_logit_softcapping = float(network_config.get("final_logit_softcapping"))
 
-    def token_forward(self, input_embdings, infer_state, layer_weight):
-        logits = super().token_forward(input_embdings, infer_state, layer_weight)
+    def _postprocess_logits(self, logits: torch.Tensor) -> torch.Tensor:
         if self.final_logit_softcapping is not None and self.final_logit_softcapping > 0:
             cap = self.final_logit_softcapping
             logits = torch.tanh(logits / cap) * cap
-            if infer_state.prompt_logics is not None:
-                infer_state.prompt_logics = torch.tanh(infer_state.prompt_logics / cap) * cap
         return logits

--- a/lightllm/models/llama/layer_infer/post_layer_infer.py
+++ b/lightllm/models/llama/layer_infer/post_layer_infer.py
@@ -71,9 +71,17 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
 
         # 正常采样使用的 logits，始终只对应每个请求最后一个位置。
         ans_logics = self._lm_head_and_gather(last_input, token_num, layer_weight, infer_state)
-        # prompt_logics 保留为 [prompt_tokens, hidden_size]，由 backend 按 token
-        # 分块计算 logits 并立即提取 logprobs。这里不能一次 materialize
-        # [prompt_tokens, vocab_size]，否则长 prefill 会产生数 GB 的瞬时张量。
+        # Keep the original full-token norm + local LM-head path so BF16 GEMM
+        # numerics stay unchanged. Only the TP all-gather and FP32 conversion are
+        # deferred and chunked by the backend; prompt_logics is [local_vocab, tokens].
+        if infer_state.prompt_logics is not None:
+            prompt_hidden_states = infer_state.prompt_logics
+            infer_state.prompt_logics = self._local_lm_head(
+                prompt_hidden_states,
+                prompt_hidden_states.shape[0],
+                layer_weight,
+                infer_state,
+            )
         return self._postprocess_logits(ans_logics)
 
     def _postprocess_logits(self, logits: torch.Tensor) -> torch.Tensor:
@@ -82,19 +90,55 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
 
     def prompt_logits_forward(
         self,
-        prompt_hidden_states: torch.Tensor,
+        prompt_shard_logits: torch.Tensor,
         layer_weight: LlamaPreAndPostLayerWeight,
         dist_group,
     ) -> torch.Tensor:
-        """Compute logits for one bounded prompt-hidden-state chunk."""
-        logits = self._lm_head_and_gather(
-            prompt_hidden_states,
-            prompt_hidden_states.shape[0],
-            layer_weight,
-            infer_state=None,
-            dist_group=dist_group,
+        """Gather and convert one bounded token chunk of TP-sharded logits."""
+        logits = self._gather_local_logits(
+            prompt_shard_logits,
+            prompt_shard_logits.shape[1],
+            layer_weight.lm_head_weight_.vocab_size,
+            dist_group,
         )
         return self._postprocess_logits(logits)
+
+    def _local_lm_head(
+        self,
+        hidden: torch.Tensor,
+        token_num: int,
+        layer_weight: LlamaPreAndPostLayerWeight,
+        infer_state: LlamaInferStateInfo | None,
+    ) -> torch.Tensor:
+        normed = self._norm(hidden, infer_state, layer_weight)
+        normed = normed.permute(1, 0).view(-1, token_num)
+        local_logits = layer_weight.lm_head_weight_(input=normed, alloc_func=self.alloc_tensor)
+        normed = None
+        return local_logits
+
+    def _gather_local_logits(
+        self,
+        local_logits: torch.Tensor,
+        token_num: int,
+        vocab_size: int,
+        dist_group,
+    ) -> torch.Tensor:
+        if self.tp_world_size_ == 1:
+            gather_data = local_logits
+        else:
+            gather_data = self.alloc_tensor((vocab_size, token_num), dtype=local_logits.dtype)
+            split_indexes = np.linspace(0, vocab_size, self.tp_world_size_ + 1, dtype=np.int64)
+            all_gather(
+                [gather_data[split_indexes[i] : split_indexes[i + 1], :] for i in range(self.tp_world_size_)],
+                local_logits,
+                group=dist_group,
+                async_op=False,
+            )
+
+        ans_logics = self.alloc_tensor((token_num, vocab_size), dtype=torch.float32)
+        ans_logics[:, :] = gather_data.permute(1, 0)
+        gather_data = None
+        return ans_logics
 
     def _lm_head_and_gather(
         self,
@@ -104,29 +148,14 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         infer_state: LlamaInferStateInfo | None,
         dist_group=None,
     ) -> torch.Tensor:
-        normed = self._norm(hidden, infer_state, layer_weight)
-        normed = normed.permute(1, 0).view(-1, token_num)
-        logic_batch = layer_weight.lm_head_weight_(input=normed, alloc_func=self.alloc_tensor)
-        normed = None
-
+        local_logits = self._local_lm_head(hidden, token_num, layer_weight, infer_state)
         vocab_size = layer_weight.lm_head_weight_.vocab_size
-        if self.tp_world_size_ == 1:
-            gather_data = logic_batch
-        else:
-            gather_data = self.alloc_tensor((vocab_size, token_num), dtype=hidden.dtype)
-            split_indexes = np.linspace(0, vocab_size, self.tp_world_size_ + 1, dtype=np.int64)
-            all_gather(
-                [gather_data[split_indexes[i] : split_indexes[i + 1], :] for i in range(self.tp_world_size_)],
-                logic_batch,
-                group=infer_state.dist_group if infer_state is not None else dist_group,
-                async_op=False,
-            )
-        logic_batch = None
-
-        ans_logics = self.alloc_tensor((token_num, vocab_size), dtype=torch.float32)
-        ans_logics[:, :] = gather_data.permute(1, 0)
-        gather_data = None
-        return ans_logics
+        return self._gather_local_logits(
+            local_logits,
+            token_num,
+            vocab_size,
+            infer_state.dist_group if infer_state is not None else dist_group,
+        )
 
     def token_forward(
         self, input_embdings: torch.Tensor, infer_state: LlamaInferStateInfo, layer_weight: LlamaPreAndPostLayerWeight

--- a/lightllm/models/llama/layer_infer/post_layer_infer.py
+++ b/lightllm/models/llama/layer_infer/post_layer_infer.py
@@ -48,13 +48,6 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
             )
             last_input[:, :] = input_embdings[last_index, :]
 
-            # 在开启 return_all_prompt_logics 模式时，额外保存整个 prefill 阶段
-            # 每一个 token 位置对应的 hidden state，用于后续输出 prompt logprobs。
-            # input_embdings 本身已经是本次新增的 token（不含已缓存前缀），
-            # 仅在 chunked prefill 的 padding 场景下会多出行，padding 部分会在
-            # basemodel._create_unpad_prefill_model_output 中按实际 token 数量裁剪掉。
-            if infer_state.return_all_prompt_logics:
-                infer_state.prompt_logics = input_embdings
             return last_input, batch_size
 
         if not infer_state.is_prefill:
@@ -66,6 +59,12 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
     def _token_forward(
         self, input_embdings: torch.Tensor, infer_state: LlamaInferStateInfo, layer_weight: LlamaPreAndPostLayerWeight
     ):
+        # input_embdings already contains all newly computed prefill positions.
+        # Keep it explicitly instead of temporarily smuggling hidden states
+        # through infer_state.prompt_logics, whose output meaning is TP-local logits.
+        prompt_hidden_states = (
+            input_embdings if infer_state.is_prefill and infer_state.return_all_prompt_logics else None
+        )
         last_input, token_num = self._slice_get_last_input(input_embdings, infer_state)
         input_embdings = None
 
@@ -74,8 +73,7 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         # Keep the original full-token norm + local LM-head path so BF16 GEMM
         # numerics stay unchanged. Only the TP all-gather and FP32 conversion are
         # deferred and chunked by the backend; prompt_logics is [local_vocab, tokens].
-        if infer_state.prompt_logics is not None:
-            prompt_hidden_states = infer_state.prompt_logics
+        if prompt_hidden_states is not None:
             infer_state.prompt_logics = self._local_lm_head(
                 prompt_hidden_states,
                 prompt_hidden_states.shape[0],
@@ -88,7 +86,7 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         """Apply model-specific transformations after the LM head."""
         return logits
 
-    def prompt_logits_forward(
+    def gather_prompt_logits_chunk(
         self,
         prompt_shard_logits: torch.Tensor,
         layer_weight: LlamaPreAndPostLayerWeight,

--- a/lightllm/models/llama/layer_infer/post_layer_infer.py
+++ b/lightllm/models/llama/layer_infer/post_layer_infer.py
@@ -71,26 +71,38 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
 
         # 正常采样使用的 logits，始终只对应每个请求最后一个位置。
         ans_logics = self._lm_head_and_gather(last_input, token_num, layer_weight, infer_state)
-        # 在 return_all_prompt_logics 模式下，prompt_logics 保存的是完整 prefill
-        # 的 hidden state，需要在 norm/lm_head 之前取出来，避免被 input_embdings 置空。
-        prompt_logics_hiddens = infer_state.prompt_logics
-        infer_state.prompt_logics = None
-        # 在 return_all_prompt_logics 模式下，额外计算整个 prefill 阶段所有位置的 logits，
-        # 存入返回的 prompt_logics 中，原来的 ans_logics 仅保留最后一个位置的 logits。
-        if prompt_logics_hiddens is not None:
-            prompt_token_num = prompt_logics_hiddens.shape[0]
-            infer_state.prompt_logics = self._lm_head_and_gather(
-                prompt_logics_hiddens, prompt_token_num, layer_weight, infer_state
-            )
+        # prompt_logics 保留为 [prompt_tokens, hidden_size]，由 backend 按 token
+        # 分块计算 logits 并立即提取 logprobs。这里不能一次 materialize
+        # [prompt_tokens, vocab_size]，否则长 prefill 会产生数 GB 的瞬时张量。
+        return self._postprocess_logits(ans_logics)
 
-        return ans_logics
+    def _postprocess_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Apply model-specific transformations after the LM head."""
+        return logits
+
+    def prompt_logits_forward(
+        self,
+        prompt_hidden_states: torch.Tensor,
+        layer_weight: LlamaPreAndPostLayerWeight,
+        dist_group,
+    ) -> torch.Tensor:
+        """Compute logits for one bounded prompt-hidden-state chunk."""
+        logits = self._lm_head_and_gather(
+            prompt_hidden_states,
+            prompt_hidden_states.shape[0],
+            layer_weight,
+            infer_state=None,
+            dist_group=dist_group,
+        )
+        return self._postprocess_logits(logits)
 
     def _lm_head_and_gather(
         self,
         hidden: torch.Tensor,
         token_num: int,
         layer_weight: LlamaPreAndPostLayerWeight,
-        infer_state: LlamaInferStateInfo,
+        infer_state: LlamaInferStateInfo | None,
+        dist_group=None,
     ) -> torch.Tensor:
         normed = self._norm(hidden, infer_state, layer_weight)
         normed = normed.permute(1, 0).view(-1, token_num)
@@ -106,7 +118,7 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
             all_gather(
                 [gather_data[split_indexes[i] : split_indexes[i + 1], :] for i in range(self.tp_world_size_)],
                 logic_batch,
-                group=infer_state.dist_group,
+                group=infer_state.dist_group if infer_state is not None else dist_group,
                 async_op=False,
             )
         logic_batch = None

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -424,13 +424,12 @@ class ModeBackend:
         self,
         model_input: ModelInput,
         run_reqs: List[InferReq],
-        prompt_hidden_states: Optional[torch.Tensor],
+        prompt_shard_logits: Optional[torch.Tensor],
         microbatch_index: int = 0,
     ) -> None:
-        # Prompt hidden states are intentionally converted to logits in bounded
-        # token chunks here. Materializing [all_prefill_tokens, vocab_size]
-        # would dominate GPU memory even though only top-k results are retained.
-        if not self.model.return_all_prompt_logics or prompt_hidden_states is None:
+        # Local LM-head logits keep the original full-token GEMM numerics. Only
+        # TP all-gather and FP32 postprocessing are chunked by token here.
+        if not self.model.return_all_prompt_logics or prompt_shard_logits is None:
             return
 
         mgr = PromptLogprobsCaptureManager.get_instance()
@@ -449,7 +448,7 @@ class ModeBackend:
                 row_start = start_loc + chunk_start
                 row_end = start_loc + chunk_end
                 logit_rows = self.model.compute_prompt_logits(
-                    prompt_hidden_states[row_start:row_end],
+                    prompt_shard_logits[:, row_start:row_end].contiguous(),
                     microbatch_index=microbatch_index,
                 )
 

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -447,7 +447,7 @@ class ModeBackend:
                 chunk_end = min(chunk_start + self.prompt_logprobs_chunk_size, capture_count)
                 row_start = start_loc + chunk_start
                 row_end = start_loc + chunk_end
-                logit_rows = self.model.compute_prompt_logits(
+                logit_rows = self.model.gather_prompt_logits_chunk(
                     prompt_shard_logits[:, row_start:row_end].contiguous(),
                     microbatch_index=microbatch_index,
                 )

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -101,6 +101,9 @@ class ModeBackend:
         self.load_way = kvargs["load_way"]
         self.disable_chunked_prefill = self.args.disable_chunked_prefill
         self.chunked_prefill_size = self.args.chunked_prefill_size
+        self.prompt_logprobs_chunk_size = int(os.getenv("LIGHTLLM_PROMPT_LOGPROBS_CHUNK_SIZE", "1024"))
+        if self.prompt_logprobs_chunk_size <= 0:
+            raise ValueError("LIGHTLLM_PROMPT_LOGPROBS_CHUNK_SIZE must be positive")
         self.use_dynamic_prompt_cache = not self.args.disable_dynamic_prompt_cache
         self.batch_max_tokens = self.args.batch_max_tokens
         self.eos_id: List[int] = kvargs.get("eos_id", [2])
@@ -421,12 +424,13 @@ class ModeBackend:
         self,
         model_input: ModelInput,
         run_reqs: List[InferReq],
-        prompt_logits: Optional[torch.Tensor],
+        prompt_hidden_states: Optional[torch.Tensor],
+        microbatch_index: int = 0,
     ) -> None:
-        # 仅在开启 return_all_prompt_logics（如 enable_prompt_logprobs）且存在完整的
-        # prefill logits 时，才需要捕获每个 prompt token 的 logprobs 信息。此时用于采样
-        # 的 logits 已经只对应每个请求最后一个位置，无需再处理。
-        if not self.model.return_all_prompt_logics or prompt_logits is None:
+        # Prompt hidden states are intentionally converted to logits in bounded
+        # token chunks here. Materializing [all_prefill_tokens, vocab_size]
+        # would dominate GPU memory even though only top-k results are retained.
+        if not self.model.return_all_prompt_logics or prompt_hidden_states is None:
             return
 
         mgr = PromptLogprobsCaptureManager.get_instance()
@@ -436,37 +440,49 @@ class ModeBackend:
             q_len = req_obj.prefill_need_token_num(is_chuncked_prefill=not self.disable_chunked_prefill)
             topk = req_obj.sampling_param.shm_param.prompt_logprobs
             capture_count = min(q_len, req_obj.shm_req.input_len - req_obj.cur_kv_len - 1)
-            if capture_count > 0 and topk == 0 and self.is_master_in_dp:
-                # prompt_logprobs=0 返回真实命中的 prompt token，
-                # rank 必须基于全 vocab 计算，不能用 top-k 列表位置替代。
-                logit_rows = prompt_logits[start_loc : start_loc + capture_count]
-                target_start = req_obj.cur_kv_len + 1
-                target_end = target_start + capture_count
-                target_token_ids = torch.tensor(
-                    req_obj.shm_req.shm_prompt_ids.arr[target_start:target_end].copy(),
-                    dtype=torch.long,
-                    device=logit_rows.device,
+            if capture_count <= 0 or topk < 0:
+                start_loc += q_len
+                continue
+
+            for chunk_start in range(0, capture_count, self.prompt_logprobs_chunk_size):
+                chunk_end = min(chunk_start + self.prompt_logprobs_chunk_size, capture_count)
+                row_start = start_loc + chunk_start
+                row_end = start_loc + chunk_end
+                logit_rows = self.model.compute_prompt_logits(
+                    prompt_hidden_states[row_start:row_end],
+                    microbatch_index=microbatch_index,
                 )
-                target_logits = logit_rows.gather(1, target_token_ids.long().view(-1, 1)).view(-1)
-                logprobs = target_logits.float() - torch.logsumexp(logit_rows.float(), dim=-1)
-                ranks = (logit_rows > target_logits.view(-1, 1)).sum(dim=-1, dtype=torch.int32) + 1
-                req_obj.prompt_selected_logprobs.add_chunk(target_start, target_end, logprobs, ranks)
-            elif capture_count > 0 and topk > 0 and mgr is not None and mgr.is_buffer_initialized():
-                logit_rows = prompt_logits[start_loc : start_loc + capture_count]
-                log_normalizer = torch.logsumexp(logit_rows.float(), dim=-1)
-                valid_topk = min(topk, logit_rows.shape[-1])
-                top_logits, top_token_ids = logit_rows.topk(valid_topk, dim=-1)
-                top_token_ids = top_token_ids.to(torch.int32)
-                top_logprobs = top_logits.float() - log_normalizer.view(-1, 1)
-                if valid_topk < topk:
-                    padding = (0, topk - valid_topk)
-                    top_token_ids = torch.nn.functional.pad(top_token_ids, padding, value=-1)
-                    top_logprobs = torch.nn.functional.pad(top_logprobs, padding, value=float("-inf"))
-                mgr.capture(
-                    mem_indexes=model_input.mem_indexes[start_loc : start_loc + capture_count],
-                    top_token_ids=top_token_ids,
-                    top_logprobs=top_logprobs,
-                )
+
+                if topk == 0 and self.is_master_in_dp:
+                    # prompt_logprobs=0 返回真实命中的 prompt token，
+                    # rank 必须基于全 vocab 计算，不能用 top-k 列表位置替代。
+                    target_start = req_obj.cur_kv_len + 1 + chunk_start
+                    target_end = target_start + (chunk_end - chunk_start)
+                    target_token_ids = torch.tensor(
+                        req_obj.shm_req.shm_prompt_ids.arr[target_start:target_end].copy(),
+                        dtype=torch.long,
+                        device=logit_rows.device,
+                    )
+                    target_logits = logit_rows.gather(1, target_token_ids.view(-1, 1)).view(-1)
+                    logprobs = target_logits.float() - torch.logsumexp(logit_rows.float(), dim=-1)
+                    ranks = (logit_rows > target_logits.view(-1, 1)).sum(dim=-1, dtype=torch.int32) + 1
+                    req_obj.prompt_selected_logprobs.add_chunk(target_start, target_end, logprobs, ranks)
+                elif topk > 0 and self.is_master_in_dp and mgr is not None and mgr.is_buffer_initialized():
+                    log_normalizer = torch.logsumexp(logit_rows.float(), dim=-1)
+                    valid_topk = min(topk, logit_rows.shape[-1])
+                    top_logits, top_token_ids = logit_rows.topk(valid_topk, dim=-1)
+                    top_token_ids = top_token_ids.to(torch.int32)
+                    top_logprobs = top_logits.float() - log_normalizer.view(-1, 1)
+                    if valid_topk < topk:
+                        padding = (0, topk - valid_topk)
+                        top_token_ids = torch.nn.functional.pad(top_token_ids, padding, value=-1)
+                        top_logprobs = torch.nn.functional.pad(top_logprobs, padding, value=float("-inf"))
+                    mgr.capture(
+                        mem_indexes=model_input.mem_indexes[row_start:row_end],
+                        top_token_ids=top_token_ids,
+                        top_logprobs=top_logprobs,
+                    )
+                del logit_rows
             start_loc += q_len
         return
 

--- a/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
+++ b/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
@@ -270,7 +270,9 @@ class DPChunkedPrefillBackend(ModeBackend):
         with torch.cuda.stream(g_infer_context.get_overlap_stream()):
             model_output0, model_output1 = self.model.microbatch_overlap_prefill(model_input0, model_input1)
             self._capture_prompt_logprobs_if_needed(model_input0, run_reqs0, model_output0.prompt_logics)
-            self._capture_prompt_logprobs_if_needed(model_input1, run_reqs1, model_output1.prompt_logics)
+            self._capture_prompt_logprobs_if_needed(
+                model_input1, run_reqs1, model_output1.prompt_logics, microbatch_index=1
+            )
             logits0 = model_output0.logits
             logits1 = model_output1.logits
 
@@ -696,7 +698,9 @@ class DPChunkedPrefillBackend(ModeBackend):
         with torch.cuda.stream(g_infer_context.get_overlap_stream()):
             model_output0, model_output1 = self.model.microbatch_overlap_prefill(model_input0, model_input1)
             self._capture_prompt_logprobs_if_needed(model_input0, run_reqs0, model_output0.prompt_logics)
-            self._capture_prompt_logprobs_if_needed(model_input1, run_reqs1, model_output1.prompt_logics)
+            self._capture_prompt_logprobs_if_needed(
+                model_input1, run_reqs1, model_output1.prompt_logics, microbatch_index=1
+            )
             logits0 = model_output0.logits
             logits1 = model_output1.logits
             req_num0, req_num1 = len(run_reqs0), len(run_reqs1)


### PR DESCRIPTION
## Summary

- keep `--enable_prompt_logprobs` as a service capability switch
- preserve the original full-token RMSNorm and TP-local LM-head path for identical BF16 numerics
- process TP all-gather, FP32 conversion, target logprobs, ranks, and top-k in bounded token chunks
- make the chunk size configurable with `LIGHTLLM_PROMPT_LOGPROBS_CHUNK_SIZE` (default: 1024)
- use the correct TP group for the second DP overlap microbatch and preserve Gemma4 logit softcapping

## Root cause

The prompt-logprobs path computed logits for every prefill position, then materialized a full-vocabulary TP all-gather and FP32 logits tensor before retaining only target or top-k values. Its peak GPU memory therefore scaled as `prompt_tokens * vocab_size` and could OOM on long prefills.

This change retains only TP-local BF16 logits for the full prefill and performs the expensive full-vocabulary gather and postprocessing one token chunk at a time.

## Validation

- Qwen3-4B BF16, TP=2 on H200
- exact A/B against `rl_dev` for 2,805-token and 9,004-token prompts
- `prompt_logprobs=0`: all target logprobs and ranks matched exactly
- `prompt_logprobs=5`: all top-k token IDs, ranks, and logprobs matched exactly (`max_abs_diff = 0`)
- generated tokens matched exactly
- 9k-token peak GPU memory: about 19.1/18.5 GiB after the change vs. 36.6/31.8 GiB before
- targeted `compileall` and `git diff --check` passed
