### PR TITLE
fix(pd): stop/eos must end request instead of continuing to next split block

### DIFF
--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -244,7 +244,7 @@ class HttpServerManagerForPDMaster:
                 async for sub_req_id, request_output, metadata, finish_status in results_generator:
                     # pd 分离模式下，返回的 metadata 可能序号信息可能存在不准确性。
                     assert sub_req_id == block_group_request_id
-                    if finish_status.get_finish_reason() == "length" and (not is_last_block):
+                    if finish_status.is_finished_length() and not is_last_block:
                         finish_status = FinishStatus()  # 转换为NoFinished
                     history_gen_token_strs.append(request_output)
                     prompt_tokens = min(prompt_tokens, metadata["prompt_tokens"])
@@ -255,6 +255,8 @@ class HttpServerManagerForPDMaster:
                     yield origin_request_id, request_output, metadata, finish_status
 
                 await self.remove_req(group_request_id=block_group_request_id)
+                if finish_status.is_finished():
+                    break
 
         except (ClientDisconnected, BaseException) as e:
             logger.error(f"has exception {str(e)}")


### PR DESCRIPTION
## 问题

PD 分离部署下，当 `max_new_tokens > LIGHTLLM_PD_SPLIT_MAX_NEW_TOKENS`（默认 2048）时，stop 字符串 / eos 失效，生成会越过停止串继续吐字。

## 根因

pd_master 的 `_generate` 会把 `max_new_tokens` 按段（默认 2048）切分循环推理。分段循环里只特判了 `finish_reason == "length"`（命中分段上限时转成 NoFinished 续算下一段）：

```python
async for sub_req_id, request_output, metadata, finish_status in results_generator:
    assert sub_req_id == block_group_request_id
    if finish_status.get_finish_reason() == "length" and (not is_last_block):
        finish_status = FinishStatus()  # 转换为NoFinished
    ...
    yield origin_group_request_id, request_output, metadata, finish_status

await self.remove_req(group_request_id=block_group_request_id)
# ← 缺少 break
```

当某一段因 **stop 字符串 / eos / abort / error** 结束时，`_wait_to_token_package` 正常返回，但外层分段循环没有 break，于是用 `prompt + history_gen_token_strs`（已含停止串文本）再起一段继续生成。而 `lightllm_generate_stream` 是把 generator 抽干的，不会因 finish 提前停止消费，所以续算真的发生，表现为停止串被无视。

当 `max_new_tokens <= 2048`（单段）时不触发，这也是该 bug 非必现的原因。

## 修复

某段以非 `length` 原因结束时，跳出分段循环。只有命中分段长度上限（`length`）才允许续算下一段。

```python
block_real_finished = False
async for sub_req_id, request_output, metadata, finish_status in results_generator:
    assert sub_req_id == block_group_request_id
    orig_finish_reason = finish_status.get_finish_reason()
    if orig_finish_reason == "length" and (not is_last_block):
        finish_status = FinishStatus()  # 转换为NoFinished
    ...
    yield origin_group_request_id, request_output, metadata, finish_status
    if orig_finish_reason not in ("length", None, ""):
        block_real_finished = True

await self.remove_req(group_request_id=block_group_request_id)
if block_real_finished:
    break
```

`abort` / `error` 同样会触发 break，避免在异常结束后还继续下一段。

## 影响范围

仅 pd_master 路径，单段场景（`max_new_tokens <= LIGHTLLM_PD_SPLIT_MAX_NEW_TOKENS`）行为不变。