### PR TITLE
fix(api): update server busy message

### DIFF
--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -7,7 +7,7 @@ logger = init_logger(__name__)
 class ServerBusyError(Exception):
     """Custom exception for server busy/overload situations"""
 
-    def __init__(self, message="Server is busy, please try again later", status_code=429):
+    def __init__(self, message="Too many requests. Please try again later.", status_code=429):
         """
         Initialize the ServerBusyError
 
@@ -21,7 +21,7 @@ class ServerBusyError(Exception):
 
     def __str__(self):
         """String representation of the error"""
-        return f"{self.message} (Status code: {self.status_code})"
+        return self.message
 
 
 class ClientDisconnected(Exception):

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -33,6 +33,7 @@ def test_server_busy_response_is_rate_limited(monkeypatch):
     body = json.loads(response.body)
 
     assert response.status_code == 429
+    assert body["error"]["message"] == "Too many requests. Please try again later."
     assert body["error"]["type"] == "RateLimitError"
     assert body["error"]["code"] == 429
     assert metric_client.counters == ["lightllm_request_failure"]
@@ -158,7 +159,7 @@ def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
         "type": "error",
         "error": {
             "type": "rate_limit_error",
-            "message": "Server is busy, please try again later (Status code: 429)",
+            "message": "Too many requests. Please try again later.",
         },
     }
     assert metric_client.counters == ["lightllm_request_failure"]


### PR DESCRIPTION
## Summary

- change the default server-busy message to `Too many requests. Please try again later.`
- return the exception message without appending the status code
- update OpenAI-compatible and Anthropic regression expectations

## Why

The existing 429 handling still returns the old `Server is busy` text and appends `(Status code: 429)` through `ServerBusyError.__str__`. This makes the response message differ from the intended rate-limit message even though the HTTP status is correct.

## Impact

Server-busy responses continue to use HTTP 429 and the existing rate-limit error types. Their message is now exactly `Too many requests. Please try again later.` across response envelopes.

## Validation

- `python3 -m py_compile lightllm/utils/error_utils.py test/test_api/test_server_busy_handling.py`
- isolated assertions for the default status, message, and string representation
- `git diff --check`

The full pytest target was not run locally because the LightLLM runtime dependencies, including pytest and torch, are not installed in this environment.
