### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 package_data = {"lightllm": ["common/all_kernel_configs/*/*.json", "common/triton_utils/*/*/*/*/*.json"]}
 setup(
     name="lightllm",
-    version="1.1.0",
+    version="1.2.0",
     packages=find_packages(exclude=("build", "include", "test", "dist", "docs", "benchmarks", "lightllm.egg-info")),
     author="model toolchain",
     author_email="",


### PR DESCRIPTION
## Summary

- update the package version in `setup.py` from `1.1.0` to `1.2.0`

## Motivation

Prepare the LightLLM package metadata for the 1.2.0 release. This changes the version reported by the package build and installation metadata; it does not change runtime behavior.

## Validation

- `git diff --check`
- `python3 setup.py --version` (returns `1.2.0`)
