### PR TITLE
修复非法 token ID 导致的 GPU 越界写

### DIFF
--- a/lightllm/server/core/objs/sampling_params.py
+++ b/lightllm/server/core/objs/sampling_params.py
@@ -21,6 +21,7 @@ JSON_SCHEMA_MAX_LENGTH = int(os.getenv("LIGHTLLM_JSON_SCHEMA_MAX_LENGTH", 2048))
 INVALID_TOKEN_IDS_MAX_LENGTH = int(os.getenv("LIGHTLLM_INVALID_TOKEN_IDS_MAX_LENGTH", 10))
 MAX_PROMPT_LOGPROBS = int(os.getenv("LIGHTLLM_MAX_PROMPT_LOGPROBS", 1024))
 MAX_SEED = (1 << 63) - 1
+_MAX_INT32 = (1 << 31) - 1
 
 
 class StopSequence(ctypes.Structure):
@@ -221,6 +222,8 @@ class InvalidTokenIds(ctypes.Structure):
         assert (
             self.size <= INVALID_TOKEN_IDS_MAX_LENGTH
         ), f"Too many invalid token IDs {self.size} > {INVALID_TOKEN_IDS_MAX_LENGTH}."
+        if not all(isinstance(token_id, int) and 0 <= token_id <= _MAX_INT32 for token_id in ids):
+            raise ValueError("invalid token IDs must be non-negative 32-bit integers")
         self.ids[: self.size] = ids[:]
         return
 

--- a/lightllm/server/router/model_infer/infer_batch.py
+++ b/lightllm/server/router/model_infer/infer_batch.py
@@ -476,9 +476,9 @@ class InferSamplingParams:
                 self.allowed_token_ids = [e for e in self.allowed_token_ids if e < vocab_size]
 
         if len(self.invalid_token_ids) > 0:
-            if not all(e < vocab_size for e in self.invalid_token_ids):
-                logger.error("invalid_token_ids contain tokenid >= vobsize, we remove these token ids")
-                self.invalid_token_ids = [e for e in self.invalid_token_ids if e < vocab_size]
+            if not all(0 <= e < vocab_size for e in self.invalid_token_ids):
+                logger.error("invalid_token_ids contain token IDs outside the vocabulary; removing them")
+                self.invalid_token_ids = [e for e in self.invalid_token_ids if 0 <= e < vocab_size]
 
         # pd decode node information
         if self.shm_param.pd_kv_trans_params.data_len > 0:

--- a/unit_tests/server/core/objs/test_invalid_token_ids.py
+++ b/unit_tests/server/core/objs/test_invalid_token_ids.py
@@ -1,0 +1,11 @@
+import pytest
+
+from lightllm.server.core.objs.sampling_params import InvalidTokenIds
+
+
+@pytest.mark.parametrize("token_id", [-1, 1 << 31])
+def test_invalid_token_ids_reject_unsafe_value(token_id):
+    token_ids = InvalidTokenIds()
+
+    with pytest.raises(ValueError):
+        token_ids.initialize([token_id])


### PR DESCRIPTION
## 问题

LightLLM 原生 `/generate` 接口会把 `logit_bias` 的键转换为 `invalid_token_ids`。原检查只有词表上界，负数 ID 会进入 Triton，并被当作 logits 指针偏移，可能造成 GPU 越界写。OpenAI 兼容接口当前会直接拒绝 `logit_bias`，不经过这条路径。

## 修改

- 写入共享内存前，只接受非负的 32 位整数
- 进入 GPU 采样前，再按 `[0, vocab_size)` 过滤一次
- 增加负数和 32 位溢出的最小回归测试

## 验证

- `python -m pytest unit_tests/server/core/objs/test_invalid_token_ids.py -q`：2 passed
- `pre-commit run --files lightllm/server/core/objs/sampling_params.py lightllm/server/router/model_infer/infer_batch.py unit_tests/server/core/objs/test_invalid_token_ids.py`
- `python -m compileall -q lightllm/server/core/objs/sampling_params.py lightllm/server/router/model_infer/infer_batch.py unit_tests/server/core/objs/test_invalid_token_ids.py`