### PR TITLE
fix: mask the head-dim padding lanes in phi3 rotary Cos/Sin loads

### DIFF
--- a/lightllm/models/phi3/triton_kernel/rotary_emb.py
+++ b/lightllm/models/phi3/triton_kernel/rotary_emb.py
@@ -25,6 +25,7 @@ def _rotary_kernel(
     HEAD_K,  # N_CTX 代表要计算的上下文长度
     rot_dim,
     head_dim,
+    NEED_DIM_MASK: tl.constexpr,
     BLOCK_HEAD: tl.constexpr,
     BLOCK_SEQ: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
@@ -53,6 +54,9 @@ def _rotary_kernel(
     )
 
     off_dimcos_sin = cur_seq_range[:, None, None] * stride_cosbs + dim_range0[None, None, :] * stride_cosd
+    cos_sin_mask = cur_seq_range[:, None, None] < max_total_len
+    if NEED_DIM_MASK:
+        cos_sin_mask = cos_sin_mask & (dim_range0[None, None, :] < rot_dim)
 
     q0 = tl.load(
         Q + off_q0,
@@ -71,12 +75,12 @@ def _rotary_kernel(
 
     cos = tl.load(
         Cos + off_dimcos_sin,
-        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        mask=cos_sin_mask,
         other=0.0,
     )
     sin = tl.load(
         Sin + off_dimcos_sin,
-        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        mask=cos_sin_mask,
         other=0.0,
     )
 
@@ -127,12 +131,12 @@ def _rotary_kernel(
     )
     cos = tl.load(
         Cos + off_dimcos_sin,
-        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        mask=cos_sin_mask,
         other=0.0,
     )
     sin = tl.load(
         Sin + off_dimcos_sin,
-        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        mask=cos_sin_mask,
         other=0.0,
     )
 
@@ -193,6 +197,7 @@ def rotary_emb_fwd(q, k, cos, sin, partial_rotary_factor=1.0):
         head_num_k,
         rot_dim,
         head_dim,
+        NEED_DIM_MASK=BLOCK_DMODEL != rot_dim,
         BLOCK_HEAD=BLOCK_HEAD,
         BLOCK_SEQ=BLOCK_SEQ,
         BLOCK_DMODEL=BLOCK_DMODEL,

--- a/lightllm/models/phi3/triton_kernel/rotary_emb.py
+++ b/lightllm/models/phi3/triton_kernel/rotary_emb.py
@@ -69,8 +69,16 @@ def _rotary_kernel(
         other=0.0,
     )
 
-    cos = tl.load(Cos + off_dimcos_sin, mask=cur_seq_range[:, None, None] < max_total_len, other=0.0)
-    sin = tl.load(Sin + off_dimcos_sin, mask=cur_seq_range[:, None, None] < max_total_len, other=0.0)
+    cos = tl.load(
+        Cos + off_dimcos_sin,
+        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        other=0.0,
+    )
+    sin = tl.load(
+        Sin + off_dimcos_sin,
+        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        other=0.0,
+    )
 
     out0 = q0 * cos - q1 * sin
     out1 = q0 * sin + q1 * cos
@@ -117,8 +125,16 @@ def _rotary_kernel(
         & (dim_range1[None, None, :] < head_dim),
         other=0.0,
     )
-    cos = tl.load(Cos + off_dimcos_sin, mask=cur_seq_range[:, None, None] < max_total_len, other=0.0)
-    sin = tl.load(Sin + off_dimcos_sin, mask=cur_seq_range[:, None, None] < max_total_len, other=0.0)
+    cos = tl.load(
+        Cos + off_dimcos_sin,
+        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        other=0.0,
+    )
+    sin = tl.load(
+        Sin + off_dimcos_sin,
+        mask=(cur_seq_range[:, None, None] < max_total_len) & (dim_range0[None, None, :] < rot_dim),
+        other=0.0,
+    )
 
     out_k0 = k0 * cos - k1 * sin
     out_k1 = k0 * sin + k1 * cos

--- a/unit_tests/models/phi3/test_rotary_emb.py
+++ b/unit_tests/models/phi3/test_rotary_emb.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from lightllm.models.phi3.triton_kernel.rotary_emb import rotary_emb_fwd
+
+
+def ref_rotary(x, cos, sin, head_dim):
+    rot = head_dim // 2
+    x = x.float()
+    x1, x2 = x[..., :rot], x[..., rot:head_dim]
+    c, s = cos.float()[:, None, :], sin.float()[:, None, :]
+    out = x.clone()
+    out[..., :rot] = x1 * c - x2 * s
+    out[..., rot:head_dim] = x1 * s + x2 * c
+    return out
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # (total_len, q_heads, k_heads, head_dim); 96 is Phi-3-mini's head_dim,
+        # whose rot_dim 48 is not a power of two, so BLOCK_DMODEL has padding
+        # lanes that every load must mask off
+        (33, 32, 32, 96),
+        (128, 32, 8, 80),
+        (64, 16, 16, 128),
+    ],
+)
+@pytest.mark.parametrize("partial_rotary_factor", [1.0, 0.5])
+def test_rotary_matches_reference(shape, partial_rotary_factor):
+    torch.manual_seed(0)
+    device = "cuda"
+    T, HQ, HK, D = shape
+    rot_dim = int(D * partial_rotary_factor) // 2
+
+    q = torch.randn(T, HQ, D, device=device, dtype=torch.float16)
+    k = torch.randn(T, HK, D, device=device, dtype=torch.float16)
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    inv = 1.0 / (10000 ** (torch.arange(0, rot_dim, device=device, dtype=torch.float32) / rot_dim))
+    angles = pos[:, None] * inv[None, :]
+    cos = angles.cos().to(torch.float16).contiguous()
+    sin = angles.sin().to(torch.float16).contiguous()
+
+    q_ref = ref_rotary(q, cos, sin, int(D * partial_rotary_factor))
+    k_ref = ref_rotary(k, cos, sin, int(D * partial_rotary_factor))
+
+    rotary_emb_fwd(q, k, cos, sin, partial_rotary_factor=partial_rotary_factor)
+
+    assert torch.allclose(q.float(), q_ref, atol=5e-3, rtol=1e-2)
+    assert torch.allclose(k.float(), k_ref, atol=5e-3, rtol=1e-2)


### PR DESCRIPTION
Fixes #1459.

The phi3 `_rotary_kernel` masks its head-dimension padding lanes (`BLOCK_DMODEL = next_power_of_2(rot_dim)`) on every q/k load and store, but the four `Cos`/`Sin` loads mask only the sequence axis, so for any `head_dim` whose half is not a power of two — Phi-3-mini's 96 gives `rot_dim=48`, `BLOCK_DMODEL=64` — the padding lanes read `Cos[s, 48..64)`, past the end of every row of the exactly-sized `(seq_len, 48)` cos/sin tensors and past the allocation on the last token, on every layer of every forward. The overrun is numerically silent (those lanes' results are masked out of the stores), so it only shows up as an allocation-boundary fault risk and under `compute-sanitizer`: 16 invalid global reads at `rotary_emb.py:72` before this change, 0 after, with bit-identical outputs.

- `rotary_emb.py`: add the `dim_range0 < rot_dim` guard (the same one the neighbouring `q0`/`k0` loads carry) to the four `Cos`/`Sin` loads.
- New `unit_tests/models/phi3/test_rotary_emb.py`: the phi3 rotary kernel's first unit tests — head_dim 96 (Phi-3-mini), 80, and 128, with `partial_rotary_factor` 1.0 and 0.5, against a float32 rotary-law reference. These guard the kernel's values (the out-of-bounds read itself is observable only under the sanitizer, since the affected lanes never reach the stores).

Performance is unchanged: `triton.testing.do_bench` on `rotary_emb_fwd` at T=4096, 32 heads, head_dim 96 (L40S, three interleaved runs) gives 173.0–174.0 us before vs 172.4–173.6 us after.

## Environment

- Base commit: 2c27b814 (main)
- NVIDIA L40S (sm_89), driver CUDA 12.4
- torch 2.6.0+cu124, triton 3.2.0, Python 3.10
