### PR TITLE
fix(pd): prevent PD master disconnects under load

### DIFF
--- a/lightllm/server/httpserver/pd_loop.py
+++ b/lightllm/server/httpserver/pd_loop.py
@@ -90,7 +90,8 @@ async def _pd_handle_task(manager: HttpServerManager, pd_master_obj: PD_Master_O
                 uri,
                 max_size=get_lightllm_websocket_max_message_size(),
                 max_queue=(2048 * 1024, 2048 * 1023),  # 关键修改
-                ping_interval=None, # 下方应用层心跳已负责存活检测，禁用协议层 keepalive，避免繁忙连接被误断。
+                # 下方应用层心跳已负责存活检测，禁用协议层 keepalive，避免繁忙连接被误断。
+                ping_interval=None,
             ) as websocket:
 
                 sock = websocket.transport.get_extra_info("socket")

--- a/lightllm/server/httpserver/pd_loop.py
+++ b/lightllm/server/httpserver/pd_loop.py
@@ -90,6 +90,7 @@ async def _pd_handle_task(manager: HttpServerManager, pd_master_obj: PD_Master_O
                 uri,
                 max_size=get_lightllm_websocket_max_message_size(),
                 max_queue=(2048 * 1024, 2048 * 1023),  # 关键修改
+                ping_interval=None, # 下方应用层心跳已负责存活检测，禁用协议层 keepalive，避免繁忙连接被误断。
             ) as websocket:
 
                 sock = websocket.transport.get_extra_info("socket")

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -152,7 +152,7 @@ class HttpServerManagerForPDMaster:
         await multimodal_params.verify_and_preload(request)
         # 计算输入的 input_token_num, 进行校验，如果输入+输出参数设置太长，则将
         # sampling_params 的参数进行修正。
-        input_token_num = self.tokens(prompt, multimodal_params, sampling_params)
+        input_token_num = await asyncio.to_thread(self.tokens, prompt, multimodal_params, sampling_params)
         fake_prompt_ids = [0 for _ in range(input_token_num)]
         from lightllm.server.httpserver.manager import HttpServerManager
 


### PR DESCRIPTION
## Summary

- offload PD master token counting from the asyncio event loop
- disable redundant WebSocket protocol pings on P/D clients
- retain the existing application-level heartbeat and timeout for liveness detection

This prevents CPU-heavy tokenization or a busy control channel from causing false WebSocket keepalive disconnects.