### PR TITLE
fix: expose thinking in Anthropic Messages API

### DIFF
--- a/docs/EN/source/tutorial/anthropic.rst
+++ b/docs/EN/source/tutorial/anthropic.rst
@@ -63,7 +63,9 @@ Known limitations
 
 - Prompt caching (``cache_control``) is accepted but ignored; ``cache_*``
   fields in ``usage`` are always zero.
-- Extended thinking (``thinking`` parameter) is not supported.
+- Extended thinking (``thinking: {"type": "enabled"}``) is supported and
+  returned as Anthropic ``thinking`` content blocks. The requested thinking
+  budget is currently not enforced separately from ``max_tokens``.
 - The Batch API (``/v1/messages/batches``) and Files API are not implemented.
 - Model name is accepted but ignored; LightLLM always serves the model
   loaded via ``--model_dir`` and echoes the requested name back in the response.

--- a/lightllm/server/api_anthropic.py
+++ b/lightllm/server/api_anthropic.py
@@ -98,6 +98,23 @@ def _anthropic_to_chat_request(anthropic_body: Dict[str, Any]) -> Tuple[Dict[str
     """
     adapter = get_anthropic_messages_adapter()
 
+    # LiteLLM's Anthropic request schema does not accept the native
+    # ``thinking`` parameter.  Translate it to the LightLLM controls before
+    # handing the request to LiteLLM, then remove the Anthropic-only field.
+    # This also makes the native Anthropic spelling behave the same as the
+    # existing ``extra_body.chat_template_kwargs`` escape hatch.
+    anthropic_body = dict(anthropic_body)
+    thinking = anthropic_body.pop("thinking", None)
+    if isinstance(thinking, dict) and thinking.get("type") in {"enabled", "disabled"}:
+        extra_body = dict(anthropic_body.get("extra_body") or {})
+        chat_template_kwargs = dict(extra_body.get("chat_template_kwargs") or {})
+        chat_template_kwargs["enable_thinking"] = thinking["type"] == "enabled"
+        extra_body["chat_template_kwargs"] = chat_template_kwargs
+        # Anthropic has a separate thinking content block, so make sure the
+        # downstream response keeps reasoning separate from normal text.
+        extra_body["separate_reasoning"] = True
+        anthropic_body["extra_body"] = extra_body
+
     _replace_anthropic_pdf_documents(anthropic_body)
     tool_result_image_urls = _tool_result_image_urls(anthropic_body)
     openai_request, tool_name_mapping = adapter.translate_anthropic_to_openai(anthropic_body)
@@ -671,6 +688,27 @@ _FINISH_REASON_TO_STOP_REASON = {
 }
 
 
+def _extract_reasoning_text(openai_dict: Dict[str, Any]) -> str:
+    """Return reasoning emitted by either of LightLLM's response fields."""
+    choice = (openai_dict.get("choices") or [{}])[0]
+    message = choice.get("message") or {}
+    for key in ("reasoning_content", "reasoning"):
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _prepend_thinking_block(result: Dict[str, Any], reasoning_text: str) -> None:
+    """Expose OpenAI reasoning as the Anthropic extended-thinking block."""
+    if not reasoning_text:
+        return
+    content = result.setdefault("content", [])
+    if any(isinstance(block, dict) and block.get("type") == "thinking" for block in content):
+        return
+    content.insert(0, {"type": "thinking", "thinking": reasoning_text})
+
+
 def _chat_response_to_anthropic(
     chat_response: Any,
     tool_name_mapping: Dict[str, str],
@@ -688,6 +726,14 @@ def _chat_response_to_anthropic(
         openai_dict = chat_response.model_dump(exclude_none=True)
     else:
         openai_dict = dict(chat_response)
+    reasoning_text = _extract_reasoning_text(openai_dict)
+
+    # LiteLLM currently consumes ``reasoning_content`` but not LightLLM's
+    # legacy ``reasoning`` field.  Normalise both names before translation;
+    # the post-translation guard below covers adapters that drop the field.
+    if reasoning_text:
+        message = ((openai_dict.get("choices") or [{}])[0]).get("message") or {}
+        message.setdefault("reasoning_content", reasoning_text)
 
     try:
         # Lazy import so this module stays importable when litellm is absent.
@@ -704,7 +750,9 @@ def _chat_response_to_anthropic(
     else:
         result = dict(anthropic_obj)
 
-    return _normalize_anthropic_response(result, requested_model)
+    result = _normalize_anthropic_response(result, requested_model)
+    _prepend_thinking_block(result, reasoning_text)
+    return result
 
 
 def _normalize_anthropic_response(result: Dict[str, Any], requested_model: str) -> Dict[str, Any]:
@@ -754,6 +802,12 @@ def _fallback_openai_to_anthropic(openai_dict: Dict[str, Any], requested_model: 
     if message.get("tool_calls"):
         raise RuntimeError("Fallback translator cannot handle tool_calls; LiteLLM adapter path is required.")
     text = message.get("content") or ""
+    reasoning_text = _extract_reasoning_text(openai_dict)
+    content = []
+    if reasoning_text:
+        content.append({"type": "thinking", "thinking": reasoning_text})
+    if text:
+        content.append({"type": "text", "text": text})
     usage = openai_dict.get("usage") or {}
     finish_reason = choice.get("finish_reason")
     return {
@@ -761,7 +815,7 @@ def _fallback_openai_to_anthropic(openai_dict: Dict[str, Any], requested_model: 
         "type": "message",
         "role": "assistant",
         "model": requested_model,
-        "content": [{"type": "text", "text": text}],
+        "content": content,
         "stop_reason": _FINISH_REASON_TO_STOP_REASON.get(finish_reason, "end_turn"),
         "stop_sequence": None,
         "usage": {
@@ -811,7 +865,8 @@ async def _openai_sse_to_anthropic_events(
     next_content_index = 0
 
     # Currently open content block, if any.
-    # current_open is either None or a tuple ("text"|"tool_use", anthropic_index).
+    # current_open is either None or a tuple
+    # ("thinking"|"text"|"tool_use", anthropic_index).
     current_open = None
 
     text_block_index = None  # Anthropic index of the active text block.
@@ -910,6 +965,35 @@ async def _openai_sse_to_anthropic_events(
                                 "cache_read_input_tokens": 0,
                             },
                         },
+                    },
+                )
+
+            # ---- Thinking delta ----
+            reasoning_piece = delta.get("reasoning_content") or delta.get("reasoning")
+            if reasoning_piece:
+                if current_open is None or current_open[0] != "thinking":
+                    if current_open is not None:
+                        yield _sse_event(
+                            "content_block_stop",
+                            {"type": "content_block_stop", "index": current_open[1]},
+                        )
+                    thinking_block_index = next_content_index
+                    next_content_index += 1
+                    current_open = ("thinking", thinking_block_index)
+                    yield _sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": thinking_block_index,
+                            "content_block": {"type": "thinking", "thinking": ""},
+                        },
+                    )
+                yield _sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": current_open[1],
+                        "delta": {"type": "thinking_delta", "thinking": reasoning_piece},
                     },
                 )
 

--- a/lightllm/server/api_anthropic.py
+++ b/lightllm/server/api_anthropic.py
@@ -88,6 +88,23 @@ def get_anthropic_messages_adapter() -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _preserve_replayed_thinking(openai_dict: Dict[str, Any]) -> None:
+    """Move LiteLLM's thinking blocks to a field understood by LightLLM."""
+    for message in openai_dict.get("messages") or []:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        thinking_blocks = message.pop("thinking_blocks", None)
+        if not isinstance(thinking_blocks, list):
+            continue
+        reasoning_text = "".join(
+            block.get("thinking", "")
+            for block in thinking_blocks
+            if isinstance(block, dict) and block.get("type") == "thinking" and isinstance(block.get("thinking"), str)
+        )
+        if reasoning_text and not message.get("reasoning_content"):
+            message["reasoning_content"] = reasoning_text
+
+
 def _anthropic_to_chat_request(anthropic_body: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, str]]:
     """Translate an Anthropic Messages request body into a dict suitable
     for constructing a LightLLM ``ChatCompletionRequest``.
@@ -123,6 +140,8 @@ def _anthropic_to_chat_request(anthropic_body: Dict[str, Any]) -> Tuple[Dict[str
         openai_dict = openai_request.model_dump(exclude_none=True)
     else:
         openai_dict = dict(openai_request)
+
+    _preserve_replayed_thinking(openai_dict)
 
     if "max_tokens" not in openai_dict and "max_completion_tokens" not in openai_dict:
         if "max_tokens" in anthropic_body:
@@ -686,6 +705,7 @@ _FINISH_REASON_TO_STOP_REASON = {
     "tool_calls": "tool_use",
     None: "end_turn",
 }
+_SYNTHETIC_THINKING_SIGNATURE = "lightllm"
 
 
 def _extract_reasoning_text(openai_dict: Dict[str, Any]) -> str:
@@ -706,7 +726,14 @@ def _prepend_thinking_block(result: Dict[str, Any], reasoning_text: str) -> None
     content = result.setdefault("content", [])
     if any(isinstance(block, dict) and block.get("type") == "thinking" for block in content):
         return
-    content.insert(0, {"type": "thinking", "thinking": reasoning_text})
+    content.insert(
+        0,
+        {
+            "type": "thinking",
+            "thinking": reasoning_text,
+            "signature": _SYNTHETIC_THINKING_SIGNATURE,
+        },
+    )
 
 
 def _chat_response_to_anthropic(
@@ -783,6 +810,10 @@ def _normalize_anthropic_response(result: Dict[str, Any], requested_model: str) 
             continue
         if block.get("type") == "text" and not block.get("text"):
             continue
+        if block.get("type") == "thinking":
+            signature = block.get("signature")
+            if not isinstance(signature, str) or not signature:
+                block["signature"] = _SYNTHETIC_THINKING_SIGNATURE
         block.pop("provider_specific_fields", None)
         cleaned_content.append(block)
     result["content"] = cleaned_content
@@ -805,7 +836,13 @@ def _fallback_openai_to_anthropic(openai_dict: Dict[str, Any], requested_model: 
     reasoning_text = _extract_reasoning_text(openai_dict)
     content = []
     if reasoning_text:
-        content.append({"type": "thinking", "thinking": reasoning_text})
+        content.append(
+            {
+                "type": "thinking",
+                "thinking": reasoning_text,
+                "signature": _SYNTHETIC_THINKING_SIGNATURE,
+            }
+        )
     if text:
         content.append({"type": "text", "text": text})
     usage = openai_dict.get("usage") or {}
@@ -835,6 +872,33 @@ def _fallback_openai_to_anthropic(openai_dict: Dict[str, Any], requested_model: 
 def _sse_event(event_type: str, data_obj: Dict[str, Any]) -> bytes:
     """Encode an Anthropic-style SSE event."""
     return f"event: {event_type}\ndata: {json.dumps(data_obj)}\n\n".encode("utf-8")
+
+
+def _content_block_close_events(current_open: tuple[str, int]) -> list[bytes]:
+    """Return the protocol events required to close an Anthropic block."""
+    block_type, block_index = current_open
+    events = []
+    if block_type == "thinking":
+        events.append(
+            _sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": block_index,
+                    "delta": {
+                        "type": "signature_delta",
+                        "signature": _SYNTHETIC_THINKING_SIGNATURE,
+                    },
+                },
+            )
+        )
+    events.append(
+        _sse_event(
+            "content_block_stop",
+            {"type": "content_block_stop", "index": block_index},
+        )
+    )
+    return events
 
 
 def _anthropic_error_type(error: Dict[str, Any]) -> str:
@@ -973,10 +1037,8 @@ async def _openai_sse_to_anthropic_events(
             if reasoning_piece:
                 if current_open is None or current_open[0] != "thinking":
                     if current_open is not None:
-                        yield _sse_event(
-                            "content_block_stop",
-                            {"type": "content_block_stop", "index": current_open[1]},
-                        )
+                        for event in _content_block_close_events(current_open):
+                            yield event
                     thinking_block_index = next_content_index
                     next_content_index += 1
                     current_open = ("thinking", thinking_block_index)
@@ -985,7 +1047,7 @@ async def _openai_sse_to_anthropic_events(
                         {
                             "type": "content_block_start",
                             "index": thinking_block_index,
-                            "content_block": {"type": "thinking", "thinking": ""},
+                            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
                         },
                     )
                 yield _sse_event(
@@ -1002,10 +1064,8 @@ async def _openai_sse_to_anthropic_events(
             if content_piece:
                 if current_open is None or current_open[0] != "text":
                     if current_open is not None:
-                        yield _sse_event(
-                            "content_block_stop",
-                            {"type": "content_block_stop", "index": current_open[1]},
-                        )
+                        for event in _content_block_close_events(current_open):
+                            yield event
                     text_block_index = next_content_index
                     next_content_index += 1
                     current_open = ("text", text_block_index)
@@ -1055,10 +1115,8 @@ async def _openai_sse_to_anthropic_events(
                     # Close whatever block is currently open (text or a
                     # previous tool_use) before opening this one.
                     if current_open is not None:
-                        yield _sse_event(
-                            "content_block_stop",
-                            {"type": "content_block_stop", "index": current_open[1]},
-                        )
+                        for event in _content_block_close_events(current_open):
+                            yield event
                     state["anthropic_index"] = next_content_index
                     next_content_index += 1
                     current_open = ("tool_use", state["anthropic_index"])
@@ -1098,10 +1156,8 @@ async def _openai_sse_to_anthropic_events(
                     if new_args:
                         if current_open is None or current_open != ("tool_use", state["anthropic_index"]):
                             if current_open is not None:
-                                yield _sse_event(
-                                    "content_block_stop",
-                                    {"type": "content_block_stop", "index": current_open[1]},
-                                )
+                                for event in _content_block_close_events(current_open):
+                                    yield event
                             current_open = ("tool_use", state["anthropic_index"])
                             yield _sse_event(
                                 "content_block_start",
@@ -1133,10 +1189,8 @@ async def _openai_sse_to_anthropic_events(
 
     # Close any still-open content block.
     if current_open is not None:
-        yield _sse_event(
-            "content_block_stop",
-            {"type": "content_block_stop", "index": current_open[1]},
-        )
+        for event in _content_block_close_events(current_open):
+            yield event
 
     # message_delta carries the final stop_reason and cumulative output_tokens.
     if message_started:

--- a/test/test_api/test_anthropic_extra_body.py
+++ b/test/test_api/test_anthropic_extra_body.py
@@ -22,6 +22,7 @@ from lightllm.server.api_anthropic import (
     _fallback_openai_to_anthropic,
     _openai_sse_to_anthropic_events,
 )
+from lightllm.server.api_models import ChatCompletionRequest
 
 
 def _base_body():
@@ -138,6 +139,28 @@ def test_native_thinking_parameter_is_forwarded():
     assert "thinking" not in chat_dict
 
 
+def test_replayed_thinking_is_preserved_through_request_validation():
+    body = _tool_result_body("file contents")
+    body["messages"][1]["content"].insert(
+        0,
+        {
+            "type": "thinking",
+            "thinking": "I should read the requested file.",
+            "signature": "client-signature",
+        },
+    )
+
+    chat_dict, _ = _anthropic_to_chat_request(body)
+    assistant_dict = chat_dict["messages"][1]
+    assert "thinking_blocks" not in assistant_dict
+    assert assistant_dict["reasoning_content"] == "I should read the requested file."
+
+    request = ChatCompletionRequest(**chat_dict)
+    validated_assistant = request.messages[1].model_dump(exclude_none=True)
+    assert validated_assistant["reasoning_content"] == "I should read the requested file."
+    assert validated_assistant["tool_calls"]
+
+
 def test_extra_body_multiple_fields_forwarded():
     body = _base_body()
     body["extra_body"] = {
@@ -189,7 +212,11 @@ def test_fallback_response_exposes_reasoning_as_thinking_block():
     )
 
     assert response["content"] == [
-        {"type": "thinking", "thinking": "First inspect the input."},
+        {
+            "type": "thinking",
+            "thinking": "First inspect the input.",
+            "signature": api_anthropic._SYNTHETIC_THINKING_SIGNATURE,
+        },
         {"type": "text", "text": "The answer is 42."},
     ]
 
@@ -212,6 +239,7 @@ def test_litellm_response_translation_preserves_reasoning_field():
                     "finish_reason": "stop",
                 }
             ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
         }
     )
 
@@ -219,6 +247,7 @@ def test_litellm_response_translation_preserves_reasoning_field():
 
     assert result["content"][0]["type"] == "thinking"
     assert result["content"][0]["thinking"] == "First inspect the input."
+    assert result["content"][0]["signature"] == api_anthropic._SYNTHETIC_THINKING_SIGNATURE
     assert result["content"][1] == {"type": "text", "text": "The answer is 42."}
 
 
@@ -814,10 +843,7 @@ def test_streaming_reasoning_uses_anthropic_thinking_events():
         yield _chunk({}, usage={"prompt_tokens": 3, "completion_tokens": 4})
 
     async def run():
-        return [
-            event.decode("utf-8")
-            async for event in _openai_sse_to_anthropic_events(chunks(), "m", "msg_x")
-        ]
+        return [event.decode("utf-8") async for event in _openai_sse_to_anthropic_events(chunks(), "m", "msg_x")]
 
     events = []
     for raw in asyncio.run(run()):
@@ -829,6 +855,7 @@ def test_streaming_reasoning_uses_anthropic_thinking_events():
         "content_block_start",
         "content_block_delta",
         "content_block_delta",
+        "content_block_delta",
         "content_block_stop",
         "content_block_start",
         "content_block_delta",
@@ -836,10 +863,14 @@ def test_streaming_reasoning_uses_anthropic_thinking_events():
         "message_delta",
         "message_stop",
     ]
-    assert events[1][1]["content_block"] == {"type": "thinking", "thinking": ""}
+    assert events[1][1]["content_block"] == {"type": "thinking", "thinking": "", "signature": ""}
     assert events[2][1]["delta"] == {"type": "thinking_delta", "thinking": "First "}
     assert events[3][1]["delta"] == {"type": "thinking_delta", "thinking": "think."}
-    assert events[6][1]["delta"] == {"type": "text_delta", "text": "42"}
+    assert events[4][1]["delta"] == {
+        "type": "signature_delta",
+        "signature": api_anthropic._SYNTHETIC_THINKING_SIGNATURE,
+    }
+    assert events[7][1]["delta"] == {"type": "text_delta", "text": "42"}
 
 
 def test_chat_response_translation_failure_returns_valid_json():

--- a/test/test_api/test_anthropic_extra_body.py
+++ b/test/test_api/test_anthropic_extra_body.py
@@ -17,7 +17,11 @@ import ujson as json
 pytest.importorskip("litellm")
 
 import lightllm.server.api_anthropic as api_anthropic
-from lightllm.server.api_anthropic import _anthropic_to_chat_request, _openai_sse_to_anthropic_events
+from lightllm.server.api_anthropic import (
+    _anthropic_to_chat_request,
+    _fallback_openai_to_anthropic,
+    _openai_sse_to_anthropic_events,
+)
 
 
 def _base_body():
@@ -123,6 +127,17 @@ def test_extra_body_chat_template_kwargs_forwarded():
     assert "extra_body" not in chat_dict
 
 
+def test_native_thinking_parameter_is_forwarded():
+    body = _base_body()
+    body["thinking"] = {"type": "enabled", "budget_tokens": 128}
+
+    chat_dict, _ = _anthropic_to_chat_request(body)
+
+    assert chat_dict["chat_template_kwargs"]["enable_thinking"] is True
+    assert chat_dict["separate_reasoning"] is True
+    assert "thinking" not in chat_dict
+
+
 def test_extra_body_multiple_fields_forwarded():
     body = _base_body()
     body["extra_body"] = {
@@ -155,6 +170,56 @@ def test_missing_extra_body_is_noop():
     chat_dict, _ = _anthropic_to_chat_request(body)
     assert "extra_body" not in chat_dict
     assert "chat_template_kwargs" not in chat_dict
+
+
+def test_fallback_response_exposes_reasoning_as_thinking_block():
+    response = _fallback_openai_to_anthropic(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "reasoning": "First inspect the input.",
+                        "content": "The answer is 42.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+        "test-model",
+    )
+
+    assert response["content"] == [
+        {"type": "thinking", "thinking": "First inspect the input."},
+        {"type": "text", "text": "The answer is 42."},
+    ]
+
+
+def test_litellm_response_translation_preserves_reasoning_field():
+    from types import SimpleNamespace
+
+    response = SimpleNamespace(
+        model_dump=lambda exclude_none=True: {
+            "id": "chatcmpl-test",
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "reasoning": "First inspect the input.",
+                        "content": "The answer is 42.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+
+    result = api_anthropic._chat_response_to_anthropic(response, {}, "test-model")
+
+    assert result["content"][0]["type"] == "thinking"
+    assert result["content"][0]["thinking"] == "First inspect the input."
+    assert result["content"][1] == {"type": "text", "text": "The answer is 42."}
 
 
 def test_non_dict_extra_body_is_ignored():
@@ -739,6 +804,42 @@ def test_interleaved_tool_calls_do_not_emit_against_closed_block():
             ), f"delta for index {data['index']} but open block is {currently_open}"
             index_of_delta.append(data["index"])
     assert index_of_delta, "no deltas observed"
+
+
+def test_streaming_reasoning_uses_anthropic_thinking_events():
+    async def chunks():
+        yield _chunk({"reasoning_content": "First "})
+        yield _chunk({"reasoning_content": "think."})
+        yield _chunk({"content": "42"}, finish_reason="stop")
+        yield _chunk({}, usage={"prompt_tokens": 3, "completion_tokens": 4})
+
+    async def run():
+        return [
+            event.decode("utf-8")
+            async for event in _openai_sse_to_anthropic_events(chunks(), "m", "msg_x")
+        ]
+
+    events = []
+    for raw in asyncio.run(run()):
+        lines = raw.strip().split("\n")
+        events.append((lines[0].split(": ", 1)[1], json.loads(lines[1].split(": ", 1)[1])))
+
+    assert [event_type for event_type, _ in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert events[1][1]["content_block"] == {"type": "thinking", "thinking": ""}
+    assert events[2][1]["delta"] == {"type": "thinking_delta", "thinking": "First "}
+    assert events[3][1]["delta"] == {"type": "thinking_delta", "thinking": "think."}
+    assert events[6][1]["delta"] == {"type": "text_delta", "text": "42"}
 
 
 def test_chat_response_translation_failure_returns_valid_json():


### PR DESCRIPTION
## What

- translate Anthropic native `thinking` to LightLLM reasoning controls
- expose `reasoning` and `reasoning_content` as Anthropic thinking blocks
- translate streaming reasoning into `thinking_delta` events
- add request, response, and streaming regression tests

## Validation

- `pytest -q test/test_api/test_anthropic_extra_body.py` — 40 passed
- validated non-streaming and streaming `/v1/messages` on Qwen3.5-0.8B running on H100

The thinking budget is not enforced separately from `max_tokens` yet.