### PR TITLE
fix: account for MTP weights in KV cache profiling

### DIFF
--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -25,7 +25,12 @@ from lightllm.common.quantization import Quantcfg
 from lightllm.common.basemodel.triton_kernel.gather_token_id import gather_token, gather_token_prefill_decode_mixed
 from lightllm.utils.log_utils import init_logger
 from lightllm.utils.dist_utils import get_dp_world_size
-from lightllm.utils.envs_utils import get_env_start_args, get_llm_data_type, get_added_mtp_kv_layer_num
+from lightllm.utils.profile_max_tokens import profile_mtp_weight_memory
+from lightllm.utils.envs_utils import (
+    get_env_start_args,
+    get_llm_data_type,
+    get_added_mtp_kv_layer_num,
+)
 from lightllm.distributed.communication_op import dist_group_manager
 from lightllm.common.basemodel.batch_objs import ModelInput, ModelOutput
 from lightllm.common.basemodel.hidden_collector import (
@@ -112,7 +117,9 @@ class TpPartBaseModel:
         self._init_quant()
 
         enable_weight_cpu_backup = self.args.enable_weight_cpu_backup
-        with self.torch_memory_saver.region(tag=MemoryTag.WEIGHT, enable_cpu_backup=enable_weight_cpu_backup):
+        with profile_mtp_weight_memory(self), self.torch_memory_saver.region(
+            tag=MemoryTag.WEIGHT, enable_cpu_backup=enable_weight_cpu_backup
+        ):
             self._init_weights()
         with self.torch_memory_saver.region(tag=MemoryTag.KV_CACHE):
             self._init_req_manager()

--- a/lightllm/utils/envs_utils.py
+++ b/lightllm/utils/envs_utils.py
@@ -274,6 +274,20 @@ def get_added_mtp_kv_layer_num() -> int:
     raise ValueError(f"unsupported mtp_mode: {mtp_mode}")
 
 
+@lru_cache(maxsize=None)
+def get_mtp_weight_layer_num() -> int:
+    args = get_env_start_args()
+    mtp_mode = args.mtp_mode
+
+    if mtp_mode is None:
+        return 0
+    if mtp_mode == "vanilla_no_att":
+        return args.mtp_step
+    if mtp_mode == "eagle_no_att":
+        return 1
+    return get_added_mtp_kv_layer_num()
+
+
 def _get_mtp_draft_backbone_layer_num(draft_model_dir: str) -> int:
     with open(os.path.join(draft_model_dir, "config.json"), "r") as json_file:
         draft_config = json.load(json_file)

--- a/lightllm/utils/profile_max_tokens.py
+++ b/lightllm/utils/profile_max_tokens.py
@@ -2,10 +2,12 @@ import os
 import gc
 import json
 import torch
+from contextlib import contextmanager
 from transformers import AutoModelForCausalLM
 import argparse
 from lightllm.common.build_utils import repair_config
 from lightllm.utils.dist_utils import get_current_device_id
+from lightllm.utils.envs_utils import get_mtp_weight_layer_num
 
 data_type_dict = {"float32": 4, "float16": 2, "bfloat16": 2, "fp32": 4, "fp16": 2, "bf16": 2, "int8": 1, "int4": 0.5}
 
@@ -29,6 +31,40 @@ def get_total_gpu_memory():
     """
     total_memory = torch.cuda.get_device_properties(0).total_memory
     return total_memory / (1024 ** 3)  # Convert to GB
+
+
+def get_mtp_adjusted_mem_fraction(
+    mem_fraction: float,
+    target_weight_bytes: int,
+    target_layer_num: int,
+    mtp_layer_num: int,
+) -> float:
+    mtp_weight_bytes = target_weight_bytes * mtp_layer_num / target_layer_num
+    total_gpu_bytes = torch.cuda.get_device_properties(get_current_device_id()).total_memory
+    adjusted_mem_fraction = mem_fraction - mtp_weight_bytes / total_gpu_bytes
+    assert adjusted_mem_fraction > 0, "MTP weight reservation leaves no memory for the target model KV cache"
+    return adjusted_mem_fraction
+
+
+@contextmanager
+def profile_mtp_weight_memory(model):
+    """Reserve auto-profiled KV budget for MTP weights allocated after the target model."""
+    should_adjust = (
+        model.max_total_token_num is None and not model.is_mtp_draft_model and model.args.mtp_mode is not None
+    )
+    if not should_adjust:
+        yield
+        return
+
+    weight_memory_before = torch.cuda.memory_allocated()
+    yield
+    target_weight_bytes = torch.cuda.memory_allocated() - weight_memory_before
+    model.mem_fraction = get_mtp_adjusted_mem_fraction(
+        mem_fraction=model.mem_fraction,
+        target_weight_bytes=target_weight_bytes,
+        target_layer_num=model.config["n_layer"],
+        mtp_layer_num=get_mtp_weight_layer_num(),
+    )
 
 
 def load_config(weight_dir_):


### PR DESCRIPTION
## Summary

- keep the existing target/draft runtime and warmup initialization order unchanged
- profile the target model's actual allocated weight memory before KV cache sizing
- reserve MTP weight memory proportionally: `target_weight_bytes * mtp_layer_num / target_layer_num`
- encapsulate the measurement and adjustment in `profile_max_tokens.py`
- keep the model initialization integration flat by combining both profiling contexts in one `with`
- account for chained MTP steps and multi-layer EAGLE3/DSpark/DFlash draft backbones
- apply the adjustment only when `max_total_token_num` is auto-profiled, without adding a new runtime log

## Tests

- `pytest -q unit_tests/utils/test_speculative_utils.py unit_tests/common/basemodel/test_mtp_manager.py unit_tests/server/test_mtp_start_args.py`
- 99 passed, 3 skipped
- no test files changed