### PR TITLE
fix: detach request shared-memory handles on release

### DIFF
--- a/lightllm/server/core/objs/req.py
+++ b/lightllm/server/core/objs/req.py
@@ -312,6 +312,14 @@ class Req(ctypes.Structure):
         self.shm_logprobs.link_shm()
         return
 
+    def detach_shm_arrays(self):
+        """Detach process-local request-scoped SHM handles before slot reuse."""
+        for attr_name in ("shm_prompt_ids", "shm_logprobs"):
+            shm_array = getattr(self, attr_name, None)
+            if shm_array is not None:
+                shm_array.detach_shm()
+                delattr(self, attr_name)
+
     async def merge_final_token_metadata(
         self,
         metadata: Dict[str, Any],

--- a/lightllm/server/core/objs/shm_req_manager.py
+++ b/lightllm/server/core/objs/shm_req_manager.py
@@ -136,10 +136,6 @@ class ShmReqManager:
         req_index_in_mem = req.index_in_shm_mem
         assert req_index_in_mem < self.max_req_num
         assert self.proc_private_get_state[req_index_in_mem] == 1
-        with self.get_req_lock_by_index(req_index_in_mem):
-            req.ref_count = req.ref_count - 1
-        self.proc_private_get_state[req_index_in_mem] = 0
-
         # Req slots are reused, but prompt/logprob shared-memory handles are
         # request-scoped. Keeping a linked handle on the process-local ctypes
         # wrapper leaks file descriptors every time the slot is reused.
@@ -148,6 +144,10 @@ class ShmReqManager:
             if shm_array is not None:
                 shm_array.detach_shm()
                 delattr(req, attr_name)
+
+        with self.get_req_lock_by_index(req_index_in_mem):
+            req.ref_count = req.ref_count - 1
+        self.proc_private_get_state[req_index_in_mem] = 0
 
     async def async_put_back_req_obj(self, req: Req):
         return self.put_back_req_obj(req)

--- a/lightllm/server/core/objs/shm_req_manager.py
+++ b/lightllm/server/core/objs/shm_req_manager.py
@@ -140,6 +140,15 @@ class ShmReqManager:
             req.ref_count = req.ref_count - 1
         self.proc_private_get_state[req_index_in_mem] = 0
 
+        # Req slots are reused, but prompt/logprob shared-memory handles are
+        # request-scoped. Keeping a linked handle on the process-local ctypes
+        # wrapper leaks file descriptors every time the slot is reused.
+        for attr_name in ("shm_prompt_ids", "shm_logprobs"):
+            shm_array = getattr(req, attr_name, None)
+            if shm_array is not None:
+                shm_array.detach_shm()
+                delattr(req, attr_name)
+
     async def async_put_back_req_obj(self, req: Req):
         return self.put_back_req_obj(req)
 

--- a/lightllm/server/core/objs/shm_req_manager.py
+++ b/lightllm/server/core/objs/shm_req_manager.py
@@ -136,14 +136,7 @@ class ShmReqManager:
         req_index_in_mem = req.index_in_shm_mem
         assert req_index_in_mem < self.max_req_num
         assert self.proc_private_get_state[req_index_in_mem] == 1
-        # Req slots are reused, but prompt/logprob shared-memory handles are
-        # request-scoped. Keeping a linked handle on the process-local ctypes
-        # wrapper leaks file descriptors every time the slot is reused.
-        for attr_name in ("shm_prompt_ids", "shm_logprobs"):
-            shm_array = getattr(req, attr_name, None)
-            if shm_array is not None:
-                shm_array.detach_shm()
-                delattr(req, attr_name)
+        req.detach_shm_arrays()
 
         with self.get_req_lock_by_index(req_index_in_mem):
             req.ref_count = req.ref_count - 1

--- a/unit_tests/server/core/objs/test_req.py
+++ b/unit_tests/server/core/objs/test_req.py
@@ -37,6 +37,18 @@ def test_create_prompt_ids_shm_array(req):
     assert hasattr(req, "shm_prompt_ids")
 
 
+def test_detach_shm_arrays(req):
+    prompt_ids = req.shm_prompt_ids
+    logprobs = req.shm_logprobs
+
+    req.detach_shm_arrays()
+
+    assert prompt_ids.shm is None
+    assert logprobs.shm is None
+    assert not hasattr(req, "shm_prompt_ids")
+    assert not hasattr(req, "shm_logprobs")
+
+
 def test_get_used_tokens(req):
     req.shm_cur_kv_len = 5
     assert req.get_used_tokens() == 5

--- a/unit_tests/server/core/objs/test_shm_req_manager.py
+++ b/unit_tests/server/core/objs/test_shm_req_manager.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 import time
+from unittest.mock import MagicMock
+
 from easydict import EasyDict
 from lightllm.utils.envs_utils import set_env_start_args, get_env_start_args
 from lightllm.server.core.objs.shm_req_manager import ShmReqManager
@@ -67,8 +69,16 @@ def test_get_req_obj_by_index(shm_req_manager):
 def test_put_back_req_obj(shm_req_manager):
     index = shm_req_manager.alloc_req_index()
     req_obj = shm_req_manager.get_req_obj_by_index(index)
+    prompt_ids = req_obj.shm_prompt_ids = MagicMock()
+    logprobs = req_obj.shm_logprobs = MagicMock()
+
     shm_req_manager.put_back_req_obj(req_obj)
+
     assert req_obj.ref_count == 0
+    prompt_ids.detach_shm.assert_called_once_with()
+    logprobs.detach_shm.assert_called_once_with()
+    assert not hasattr(req_obj, "shm_prompt_ids")
+    assert not hasattr(req_obj, "shm_logprobs")
     shm_req_manager.release_req_index(index)
 
 


### PR DESCRIPTION
## Summary

- detach prompt and logprob shared-memory handles when a process returns a request object
- remove the stale process-local attributes so later users relink cleanly
- extend the existing request-manager unit test to cover both handles

## Root cause

Request slots are reused, while each prompt/logprob shared-memory link owns a process-local file descriptor. put_back_req_obj previously updated only the request reference count and process-local borrow state. If the ctypes wrapper stayed reachable, its linked handles also stayed open across slot reuse, allowing file descriptors to accumulate.

## Safety

ShmArray.detach_shm closes only the current process handle and does not unlink the shared-memory segment. Other processes and later requests can continue using or relink the segment.

## Validation

- PYTHONPATH=. pytest -q unit_tests/server/core/objs/test_shm_req_manager.py::test_put_back_req_obj
- pre-commit run --files lightllm/server/core/objs/shm_req_manager.py unit_tests/server/core/objs/test_shm_req_manager.py
- git diff --check