### PR TITLE
perf(pd): avoid duplicate prompt ID payloads

### DIFF
--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -10,6 +10,7 @@ import copy
 import hashlib
 import datetime
 import pickle
+from array import array
 from frozendict import frozendict
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -397,7 +398,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
                     f"pd prefill node upload group_req_id {group_request_id} prompt ids len : {len(prompt_ids)}"
                 )
                 await pd_upload_websocket.send(
-                    pickle.dumps((ObjType.PD_UPLOAD_PREFILL_PROMPT_IDS, group_request_id, prompt_ids))
+                    pickle.dumps((ObjType.PD_UPLOAD_PREFILL_PROMPT_IDS, group_request_id, array("i", prompt_ids)))
                 )
                 try:
                     await asyncio.wait_for(pd_event.wait(), timeout=180)
@@ -737,9 +738,6 @@ class HttpServerManager(HttpRlManagerHelper, object):
                 for sub_req_id, out_str, metadata, finish_status in req_status.out_token_info_list:
                     # pd master 节点需要这个做统计信息， 所以放在元数据中返回给 pd master 节点
                     metadata["prompt_tokens"] = prompt_tokens
-                    # p 节点返回 prompt_ids 信息，防止 d 节点重新 encode
-                    if self.pd_mode.is_P() and is_first_token:
-                        metadata["prompt_ids"] = prompt_ids
 
                     gpu_prompt_cache_len = metadata.pop("prompt_cache_len", 0)
                     cpu_prompt_cache_len = metadata.pop("cpu_prompt_cache_len", 0)


### PR DESCRIPTION
## Summary

- Stop duplicating the full `prompt_ids` sequence in first-token metadata; PD master already receives it through `PD_UPLOAD_PREFILL_PROMPT_IDS`.
- Encode the remaining dedicated upload as a contiguous signed-int buffer instead of a Python-int list.

## Why

For long prompts, the old path serialized/deserialized the same large Python list twice. In the historical 32K benchmark behind `cfce087`, deserializing the list took about 0.451 ms versus about 0.0087 ms for the contiguous buffer. This PR isolates that transport change from the other PD hot-path optimizations.

## Validation

- Production-code diff passes repository black and flake8 hooks.