### PR TITLE
fix(qwen3.5): align shared expert gate precision

### DIFF
--- a/lightllm/models/qwen3next/triton_kernel/shared_expert_gate.py
+++ b/lightllm/models/qwen3next/triton_kernel/shared_expert_gate.py
@@ -19,12 +19,16 @@ def _sigmoid_mul_kernel(
     offs = tl.arange(0, BLOCK_N)
     mask = offs < N
     x_ptrs = x + row * stride_x_m + offs * stride_x_n
-    x_vals = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
+    x_vals = tl.load(x_ptrs, mask=mask, other=0.0)
     if GATE_N == 1:
         gate_vals = tl.load(gate + row * stride_g_m).to(tl.float32)
     else:
         gate_vals = tl.load(gate + row * stride_g_m + offs * stride_g_n, mask=mask, other=0.0).to(tl.float32)
-    gate_vals = tl.sigmoid(gate_vals)
+    # Match the official Qwen3.5 implementation, ``output * torch.sigmoid(gate)``:
+    # materialize the sigmoid result in the gate dtype before multiplication.
+    gate_vals = tl.sigmoid(gate_vals).to(gate.dtype.element_ty)
+    # Qwen3.5 uses BF16, so keep both rounded operands in BF16 for the direct
+    # multiply.
     tl.store(x_ptrs, (x_vals * gate_vals).to(x.dtype.element_ty), mask=mask)
 
 

--- a/unit_tests/models/qwen3next/test_shared_expert_gate.py
+++ b/unit_tests/models/qwen3next/test_shared_expert_gate.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from lightllm.models.qwen3next.triton_kernel.shared_expert_gate import sigmoid_mul_
+
+
+@pytest.mark.parametrize("gate_width", [1, 6144])
+def test_sigmoid_mul_matches_unfused_dtype_rounding(gate_width):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    torch.manual_seed(2026)
+    x = torch.randn((17, 6144), device="cuda", dtype=torch.bfloat16) * 2
+    gate = torch.randn((17, gate_width), device="cuda", dtype=torch.bfloat16) * 3
+
+    expected = x.clone()
+    expected.mul_(gate.clone().sigmoid_())
+
+    actual = x.clone()
+    sigmoid_mul_(actual, gate)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- match the official Qwen3.5 `output * torch.sigmoid(gate)` BF16 rounding semantics in the fused shared-expert gate
- materialize sigmoid in the gate dtype before multiplying and keep the output operand in its source dtype
- add exact-match coverage for scalar and elementwise gate layouts

## Motivation

The previous fused kernel promoted both operands to FP32, which can shift rollout token distributions relative to the official unfused implementation.

## Validation

- H200 GPU exact-match check for `gate_width=1`
- H200 GPU exact-match check for `gate_width=6144`
- both cases pass with `rtol=0, atol=0`
- Python syntax and `git diff --check` pass

The test container does not include pytest, so the two test cases were also executed directly with equivalent assertions.