### PR TITLE
fix(api): support reasoning_effort none

### DIFF
--- a/docs/CN/source/tutorial/reasoning_parser.rst
+++ b/docs/CN/source/tutorial/reasoning_parser.rst
@@ -267,6 +267,12 @@ GPT-OSS
 **stream_reasoning** (布尔, 默认 False)
   是否实时流式传输推理内容
 
+**reasoning_effort** (字符串, 可选)
+  接受的推理强度：``none``、``minimal``、``low``、``medium``、``high``、``xhigh`` 或 ``max``；
+  非 ``none`` 级别的实际支持情况取决于模型的聊天模板。
+  对于兼容的聊天模板，``none`` 会自动关闭思考模式；``chat_template_kwargs`` 中显式设置的
+  ``thinking`` 或 ``enable_thinking`` 优先级更高。
+
 **chat_template_kwargs** (对象)
   - ``enable_thinking``: 启用推理（Qwen3, GLM45）
   - ``thinking``: 启用推理（DeepSeek-V3）

--- a/docs/EN/source/tutorial/reasoning_parser.rst
+++ b/docs/EN/source/tutorial/reasoning_parser.rst
@@ -267,6 +267,12 @@ Configuration
 **stream_reasoning** (bool, default: False)
   Whether to stream reasoning content in real-time
 
+**reasoning_effort** (string, optional)
+  Accepted reasoning level: ``none``, ``minimal``, ``low``, ``medium``, ``high``, ``xhigh``, or ``max``.
+  Support for non-``none`` levels depends on the model's chat template.
+  ``none`` automatically disables thinking for compatible chat templates. Explicit
+  ``thinking`` or ``enable_thinking`` values in ``chat_template_kwargs`` take priority.
+
 **chat_template_kwargs** (object)
   - ``enable_thinking``: Enable reasoning (Qwen3, GLM45)
   - ``thinking``: Enable reasoning (DeepSeek-V3)

--- a/lightllm/server/api_models.py
+++ b/lightllm/server/api_models.py
@@ -223,7 +223,7 @@ class ChatCompletionRequest(BaseModel):
     parallel_tool_calls: Optional[bool] = True
 
     # OpenAI parameters for reasoning and others
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]] = None
     chat_template_kwargs: Optional[Dict] = None
     separate_reasoning: Optional[bool] = True
     stream_reasoning: Optional[bool] = False
@@ -271,7 +271,13 @@ class ChatCompletionRequest(BaseModel):
 
     @model_validator(mode="after")
     def sync_thinking_chat_template_kwargs(self):
-        """Mirror thinking <-> enable_thinking when only one is set (Qwen vs DeepSeek templates)."""
+        """Resolve reasoning effort and mirror the thinking template aliases."""
+        if self.reasoning_effort is not None:
+            if self.chat_template_kwargs is None:
+                self.chat_template_kwargs = {}
+            if "thinking" not in self.chat_template_kwargs and "enable_thinking" not in self.chat_template_kwargs:
+                self.chat_template_kwargs["enable_thinking"] = self.reasoning_effort != "none"
+
         if not self.chat_template_kwargs:
             return self
         if "thinking" not in self.chat_template_kwargs and "enable_thinking" in self.chat_template_kwargs:

--- a/lightllm/server/build_prompt.py
+++ b/lightllm/server/build_prompt.py
@@ -141,6 +141,9 @@ async def build_prompt(request, tools) -> str:
     if request.role_settings:
         kwargs["role_setting"] = request.role_settings
 
+    if request.reasoning_effort is not None:
+        kwargs["reasoning_effort"] = request.reasoning_effort
+
     if request.chat_template_kwargs:
         kwargs.update(request.chat_template_kwargs)
 

--- a/test/test_api/test_reasoning_effort.py
+++ b/test/test_api/test_reasoning_effort.py
@@ -1,0 +1,56 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+import lightllm.server.api_openai as api_openai
+import lightllm.server.build_prompt as build_prompt_module
+from lightllm.server.api_models import ChatCompletionRequest
+
+
+def _request(**kwargs):
+    return ChatCompletionRequest(messages=[{"role": "user", "content": "hello"}], **kwargs)
+
+
+@pytest.mark.parametrize("effort", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+def test_reasoning_effort_is_accepted_and_controls_thinking(effort):
+    request = _request(reasoning_effort=effort)
+
+    expected = effort != "none"
+    assert request.chat_template_kwargs["enable_thinking"] is expected
+    assert request.chat_template_kwargs["thinking"] is expected
+
+
+def test_unsupported_reasoning_effort_is_rejected():
+    with pytest.raises(ValidationError):
+        _request(reasoning_effort="ultra")
+
+
+@pytest.mark.parametrize("template_key", ["thinking", "enable_thinking"])
+@pytest.mark.parametrize(("effort", "explicit_value"), [("none", True), ("high", False)])
+def test_explicit_thinking_setting_overrides_reasoning_effort(template_key, effort, explicit_value):
+    request = _request(reasoning_effort=effort, chat_template_kwargs={template_key: explicit_value})
+
+    assert request.chat_template_kwargs["enable_thinking"] is explicit_value
+    assert request.chat_template_kwargs["thinking"] is explicit_value
+
+
+def test_reasoning_effort_is_forwarded_to_chat_template(monkeypatch):
+    class RecordingTokenizer:
+        def apply_chat_template(self, **kwargs):
+            self.kwargs = kwargs
+            return "rendered prompt"
+
+    tokenizer = RecordingTokenizer()
+    monkeypatch.setattr(build_prompt_module, "tokenizer", tokenizer)
+    monkeypatch.setattr(build_prompt_module, "get_model_type_v1", lambda: None)
+    monkeypatch.setattr(build_prompt_module, "tokenizer_supports_force_thinking", lambda: True)
+    monkeypatch.setattr(api_openai, "get_env_start_args", lambda: SimpleNamespace(reasoning_parser="qwen3"))
+
+    prompt = asyncio.run(build_prompt_module.build_prompt(_request(reasoning_effort="none"), tools=None))
+
+    assert prompt == "rendered prompt"
+    assert tokenizer.kwargs["reasoning_effort"] == "none"
+    assert tokenizer.kwargs["enable_thinking"] is False
+    assert tokenizer.kwargs["thinking"] is False


### PR DESCRIPTION
## Summary

- accept the vLLM-compatible reasoning effort values, including none
- map none to disabled thinking for compatible templates while preserving explicit chat_template_kwargs overrides
- forward reasoning_effort to chat templates so model-specific effort levels can take effect
- document the behavior and add validation, override, and prompt-forwarding regression tests

## Tests

- python -m pytest -q unit_tests/server/test_*.py test/test_api/test_reasoning_effort.py test/test_api/test_seed_validation.py test/test_api/test_completion_multiple_choices.py (83 passed)
- Black check on changed Python files
- Flake8 on changed Python files
- git diff --check