### PR TITLE
Refactor FA3 page-table buffer reuse

### DIFF
--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -9,36 +9,39 @@ from lightllm.common.basemodel.triton_kernel.fa3_utils import (
 )
 from lightllm.common.basemodel.triton_kernel.gen_prefill_params import gen_cumsum_pad0_tensor
 from lightllm.common.basemodel.triton_kernel.mtp_utils import build_mtp_shared_group_markers
-from lightllm.utils.envs_utils import get_env_start_args
 
 
 class Fa3AttBackend(BaseAttBackend):
+    """Common fixed page-table storage for FA3 attention backends."""
+
     def __init__(self, model):
         super().__init__(model=model)
-        self.get_page_table_buffer()  # init
+        if getattr(self, "page_table_buffers", None) is not None:
+            return
 
-    def get_page_table_buffer(self):
-        """
-        用于减少 decode graph 捕获的时候, 造成显存二次方增长的情况.
-        """
-        model = self.model
-        if not hasattr(self, "_shared_page_table_buffer"):
-            max_att_batch_size = model.graph_max_batch_size
-            if not get_env_start_args().mtp_dynamic_verify:
-                # FA3 merges each fixed speculative block into one attention sequence.
-                max_att_batch_size //= model.mtp_manager.get_decode_batch_multiplier(model.is_mtp_draft_model)
+        args = model.args
+        # Dynamic verification may keep the target row and all MTP draft rows for
+        # every running request. max_seq_length is max_req_total_len plus the MTP
+        # headroom reserved when the model is initialized.
+        self.page_table_max_batch_size = args.running_max_req_size * (args.mtp_step + 1)
+        self.page_table_max_seq_len = model.max_seq_length
+        buffer_count = 2 if args.enable_decode_microbatch_overlap else 1
+        workspace_size = self.page_table_max_batch_size * self.page_table_max_seq_len
+        self.page_table_buffers = [
+            self.get_gpu_workspace_buffer(
+                key_name=f"fa3_page_table_{buffer_index}",
+                workspace_size=workspace_size,
+                dtype=torch.int32,
+            )
+            for buffer_index in range(buffer_count)
+        ]
 
-            buffer_count = 2 if model.args.enable_decode_microbatch_overlap else 1
-            workspace_size = max_att_batch_size * model.graph_max_len_in_batch
-            self._shared_page_table_buffer = [
-                self.get_gpu_workspace_buffer(
-                    key_name=f"fa3_fp_page_table_{buffer_index}",
-                    workspace_size=workspace_size,
-                    dtype=torch.int32,
-                )
-                for buffer_index in range(buffer_count)
-            ]
-        return self._shared_page_table_buffer
+    def get_page_table_view(self, att_batch_size, microbatch_index):
+        """Return a fixed-stride page-table view without allocating on the decode path."""
+        max_seq_len = self.page_table_max_seq_len
+        return self.page_table_buffers[microbatch_index][: att_batch_size * max_seq_len].reshape(
+            att_batch_size, max_seq_len
+        )
 
     def create_att_prefill_state(self, infer_state) -> "Fa3PrefillAttState":
         return Fa3PrefillAttState(backend=self, infer_state=infer_state)
@@ -199,21 +202,10 @@ class Fa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
-        # 可以使用 cuda graph的时候从 buffer中申请
-        if (
-            self.infer_state.batch_size <= model.graph_max_batch_size
-            and self.infer_state.max_kv_seq_len <= model.graph_max_len_in_batch
-        ):
-            page_buffer = self.backend.get_page_table_buffer()
-            self.page_table = page_buffer[self.infer_state.microbatch_index][
-                : att_batch_size * model.graph_max_len_in_batch
-            ].reshape(att_batch_size, model.graph_max_len_in_batch)
-        else:
-            self.page_table = torch.empty(
-                (att_batch_size, self.infer_state.max_kv_seq_len),
-                dtype=torch.int32,
-                device=self.infer_state.input_ids.device,
-            )
+        self.page_table = self.backend.get_page_table_view(
+            att_batch_size=att_batch_size,
+            microbatch_index=self.infer_state.microbatch_index,
+        )
 
         page_table_copy(
             page_table=self.page_table[:, : self.infer_state.max_kv_seq_len],

--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -14,9 +14,11 @@ from lightllm.common.basemodel.triton_kernel.mtp_utils import build_mtp_shared_g
 class Fa3AttBackend(BaseAttBackend):
     """Common fixed page-table storage for FA3 attention backends."""
 
+    page_table_buffers = None
+
     def __init__(self, model):
         super().__init__(model=model)
-        if getattr(self, "page_table_buffers", None) is not None:
+        if self.page_table_buffers is not None:
             return
 
         args = model.args

--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -218,14 +218,25 @@ class Fa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
+        actual_max_kv_len = self.infer_state.max_kv_seq_len
+        page_table_width = actual_max_kv_len
+        if model.graph is not None and model.graph.can_run(
+            batch_size=self.infer_state.batch_size,
+            max_len_in_batch=actual_max_kv_len,
+        ):
+            # CUDA Graph replay uses the shape and strides captured with the
+            # graph-wide maximum KV length. Keep that fixed row stride while
+            # writing only the valid portion of each runtime row below.
+            page_table_width = model.graph.graph_max_len_in_batch
+
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
-            max_kv_len=self.infer_state.max_kv_seq_len,
+            max_kv_len=page_table_width,
             microbatch_index=self.infer_state.microbatch_index,
         )
 
         page_table_copy(
-            page_table=self.page_table,
+            page_table=self.page_table[:, :actual_max_kv_len],
             req_to_token_indexs=model.req_manager.req_to_token_indexs,
             b_req_idx=b_att_req_idx,
         )

--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -119,7 +119,7 @@ class Fa3PrefillAttState(BasePrefillAttState):
 
         k_descale, v_descale = None, None  # disable quantization
         Lq = q.shape[-1]
-        sm_scale = 1.0 / (Lq**0.5)
+        sm_scale = 1.0 / (Lq ** 0.5)
         o = flash_attn_with_kvcache(
             q=q,
             k_cache=k.view(k.shape[0], 1, k.shape[1], k.shape[2]),
@@ -271,7 +271,7 @@ class Fa3DecodeAttState(BaseDecodeAttState):
 
         k_descale, v_descale = None, None  # disable quantization
         Lq = q.shape[-1]
-        sm_scale = 1.0 / (Lq**0.5)
+        sm_scale = 1.0 / (Lq ** 0.5)
         o = flash_attn_with_kvcache_autotune(
             q=q,
             k_cache=k.view(k.shape[0], 1, k.shape[1], k.shape[2]),

--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -44,16 +44,19 @@ class Fa3AttBackend(BaseAttBackend):
             for buffer_index in range(buffer_count)
         ]
 
-    def get_page_table_view(self, att_batch_size, microbatch_index):
-        """Return a fixed-stride page-table view without allocating on the decode path."""
+    def get_page_table_view(self, att_batch_size, max_kv_len, microbatch_index):
+        """Return a contiguous page-table view without allocating on the decode path."""
         if att_batch_size > self.page_table_max_batch_size:
             raise RuntimeError(
                 f"FA3 attention batch size {att_batch_size} exceeds page-table capacity "
                 f"{self.page_table_max_batch_size}"
             )
-        max_seq_len = self.page_table_max_seq_len
-        return self.page_table_buffers[microbatch_index][: att_batch_size * max_seq_len].reshape(
-            att_batch_size, max_seq_len
+        if max_kv_len > self.page_table_max_seq_len:
+            raise RuntimeError(
+                f"FA3 max KV sequence length {max_kv_len} exceeds page-table capacity " f"{self.page_table_max_seq_len}"
+            )
+        return self.page_table_buffers[microbatch_index][: att_batch_size * max_kv_len].reshape(
+            att_batch_size, max_kv_len
         )
 
     def create_att_prefill_state(self, infer_state) -> "Fa3PrefillAttState":
@@ -215,18 +218,14 @@ class Fa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
-        if self.infer_state.max_kv_seq_len > self.backend.page_table_max_seq_len:
-            raise RuntimeError(
-                f"FA3 max KV sequence length {self.infer_state.max_kv_seq_len} exceeds page-table capacity "
-                f"{self.backend.page_table_max_seq_len}"
-            )
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
+            max_kv_len=self.infer_state.max_kv_seq_len,
             microbatch_index=self.infer_state.microbatch_index,
         )
 
         page_table_copy(
-            page_table=self.page_table[:, : self.infer_state.max_kv_seq_len],
+            page_table=self.page_table,
             req_to_token_indexs=model.req_manager.req_to_token_indexs,
             b_req_idx=b_att_req_idx,
         )

--- a/lightllm/common/basemodel/attention/fa3/fp.py
+++ b/lightllm/common/basemodel/attention/fa3/fp.py
@@ -23,9 +23,15 @@ class Fa3AttBackend(BaseAttBackend):
 
         args = model.args
         # Dynamic verification may keep the target row and all MTP draft rows for
-        # every running request. max_seq_length is max_req_total_len plus the MTP
-        # headroom reserved when the model is initialized.
-        self.page_table_max_batch_size = args.running_max_req_size * (args.mtp_step + 1)
+        # every running request. TPSP and CUDA Graph may pad that physical batch
+        # further, so the fixed buffer must cover both execution paths.
+        running_max_batch_size = args.running_max_req_size * (args.mtp_step + 1)
+        if args.enable_tpsp_mix_mode:
+            tp_size = model.tp_world_size_
+            running_max_batch_size = (running_max_batch_size + tp_size - 1) // tp_size * tp_size
+        self.page_table_max_batch_size = max(running_max_batch_size, model.graph_max_batch_size)
+        # max_seq_length is max_req_total_len plus the MTP headroom reserved when
+        # the model is initialized.
         self.page_table_max_seq_len = model.max_seq_length
         buffer_count = 2 if args.enable_decode_microbatch_overlap else 1
         workspace_size = self.page_table_max_batch_size * self.page_table_max_seq_len
@@ -40,6 +46,11 @@ class Fa3AttBackend(BaseAttBackend):
 
     def get_page_table_view(self, att_batch_size, microbatch_index):
         """Return a fixed-stride page-table view without allocating on the decode path."""
+        if att_batch_size > self.page_table_max_batch_size:
+            raise RuntimeError(
+                f"FA3 attention batch size {att_batch_size} exceeds page-table capacity "
+                f"{self.page_table_max_batch_size}"
+            )
         max_seq_len = self.page_table_max_seq_len
         return self.page_table_buffers[microbatch_index][: att_batch_size * max_seq_len].reshape(
             att_batch_size, max_seq_len
@@ -108,7 +119,7 @@ class Fa3PrefillAttState(BasePrefillAttState):
 
         k_descale, v_descale = None, None  # disable quantization
         Lq = q.shape[-1]
-        sm_scale = 1.0 / (Lq ** 0.5)
+        sm_scale = 1.0 / (Lq**0.5)
         o = flash_attn_with_kvcache(
             q=q,
             k_cache=k.view(k.shape[0], 1, k.shape[1], k.shape[2]),
@@ -204,6 +215,11 @@ class Fa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
+        if self.infer_state.max_kv_seq_len > self.backend.page_table_max_seq_len:
+            raise RuntimeError(
+                f"FA3 max KV sequence length {self.infer_state.max_kv_seq_len} exceeds page-table capacity "
+                f"{self.backend.page_table_max_seq_len}"
+            )
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
             microbatch_index=self.infer_state.microbatch_index,
@@ -255,7 +271,7 @@ class Fa3DecodeAttState(BaseDecodeAttState):
 
         k_descale, v_descale = None, None  # disable quantization
         Lq = q.shape[-1]
-        sm_scale = 1.0 / (Lq ** 0.5)
+        sm_scale = 1.0 / (Lq**0.5)
         o = flash_attn_with_kvcache_autotune(
             q=q,
             k_cache=k.view(k.shape[0], 1, k.shape[1], k.shape[2]),

--- a/lightllm/common/basemodel/attention/fa3/mla.py
+++ b/lightllm/common/basemodel/attention/fa3/mla.py
@@ -152,6 +152,11 @@ class MlaFa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
+        if self.infer_state.max_kv_seq_len > self.backend.page_table_max_seq_len:
+            raise RuntimeError(
+                f"FA3 max KV sequence length {self.infer_state.max_kv_seq_len} exceeds page-table capacity "
+                f"{self.backend.page_table_max_seq_len}"
+            )
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
             microbatch_index=self.infer_state.microbatch_index,

--- a/lightllm/common/basemodel/attention/fa3/mla.py
+++ b/lightllm/common/basemodel/attention/fa3/mla.py
@@ -152,18 +152,14 @@ class MlaFa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
-        if self.infer_state.max_kv_seq_len > self.backend.page_table_max_seq_len:
-            raise RuntimeError(
-                f"FA3 max KV sequence length {self.infer_state.max_kv_seq_len} exceeds page-table capacity "
-                f"{self.backend.page_table_max_seq_len}"
-            )
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
+            max_kv_len=self.infer_state.max_kv_seq_len,
             microbatch_index=self.infer_state.microbatch_index,
         )
 
         page_table_copy(
-            page_table=self.page_table[:, : self.infer_state.max_kv_seq_len],
+            page_table=self.page_table,
             req_to_token_indexs=model.req_manager.req_to_token_indexs,
             b_req_idx=b_att_req_idx,
         )

--- a/lightllm/common/basemodel/attention/fa3/mla.py
+++ b/lightllm/common/basemodel/attention/fa3/mla.py
@@ -152,14 +152,25 @@ class MlaFa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
+        actual_max_kv_len = self.infer_state.max_kv_seq_len
+        page_table_width = actual_max_kv_len
+        if model.graph is not None and model.graph.can_run(
+            batch_size=self.infer_state.batch_size,
+            max_len_in_batch=actual_max_kv_len,
+        ):
+            # CUDA Graph replay uses the shape and strides captured with the
+            # graph-wide maximum KV length. Keep that fixed row stride while
+            # writing only the valid portion of each runtime row below.
+            page_table_width = model.graph.graph_max_len_in_batch
+
         self.page_table = self.backend.get_page_table_view(
             att_batch_size=att_batch_size,
-            max_kv_len=self.infer_state.max_kv_seq_len,
+            max_kv_len=page_table_width,
             microbatch_index=self.infer_state.microbatch_index,
         )
 
         page_table_copy(
-            page_table=self.page_table,
+            page_table=self.page_table[:, :actual_max_kv_len],
             req_to_token_indexs=model.req_manager.req_to_token_indexs,
             b_req_idx=b_att_req_idx,
         )

--- a/lightllm/common/basemodel/attention/fa3/mla.py
+++ b/lightllm/common/basemodel/attention/fa3/mla.py
@@ -1,43 +1,16 @@
 import dataclasses
 import torch
-from ..base_att import BaseAttBackend, BasePrefillAttState, BaseDecodeAttState, AttControl
+from ..base_att import BasePrefillAttState, BaseDecodeAttState, AttControl
 from typing import Optional, TYPE_CHECKING, Tuple
 from lightllm.utils.sgl_utils import flash_attn_with_kvcache
 from lightllm.common.basemodel.triton_kernel.fa3_utils import build_dynamic_spec_fa3_decode_params, page_table_copy
 from lightllm.common.basemodel.triton_kernel.gen_prefill_params import gen_cumsum_pad0_tensor
 from lightllm.common.basemodel.triton_kernel.mtp_utils import build_mtp_shared_group_markers
 from lightllm.utils.sgl_utils import flash_attn_varlen_func
-from lightllm.utils.envs_utils import get_env_start_args
+from .fp import Fa3AttBackend
 
 
-class MlaFa3AttBackend(BaseAttBackend):
-    def __init__(self, model):
-        super().__init__(model=model)
-        self.get_page_table_buffer()  # init
-
-    def get_page_table_buffer(self):
-        """
-        用于减少 decode graph 捕获的时候, 造成显存二次方增长的情况.
-        """
-        model = self.model
-        if not hasattr(self, "_shared_page_table_buffer"):
-            max_att_batch_size = model.graph_max_batch_size
-            if not get_env_start_args().mtp_dynamic_verify:
-                # FA3 merges each fixed speculative block into one attention sequence.
-                max_att_batch_size //= model.mtp_manager.get_decode_batch_multiplier(model.is_mtp_draft_model)
-
-            buffer_count = 2 if model.args.enable_decode_microbatch_overlap else 1
-            workspace_size = max_att_batch_size * model.graph_max_len_in_batch
-            self._shared_page_table_buffer = [
-                self.get_gpu_workspace_buffer(
-                    key_name=f"fa3_mla_page_table_{buffer_index}",
-                    workspace_size=workspace_size,
-                    dtype=torch.int32,
-                )
-                for buffer_index in range(buffer_count)
-            ]
-        return self._shared_page_table_buffer
-
+class MlaFa3AttBackend(Fa3AttBackend):
     def create_att_prefill_state(self, infer_state) -> "MlaFa3PrefillAttState":
         return MlaFa3PrefillAttState(backend=self, infer_state=infer_state)
 
@@ -179,21 +152,10 @@ class MlaFa3DecodeAttState(BaseDecodeAttState):
     def _init_page_table(self, b_att_req_idx: torch.Tensor):
         att_batch_size = b_att_req_idx.shape[0]
         model = self.backend.model
-        # 可以使用 cuda graph的时候从 buffer中申请
-        if (
-            self.infer_state.batch_size <= model.graph_max_batch_size
-            and self.infer_state.max_kv_seq_len <= model.graph_max_len_in_batch
-        ):
-            page_buffer = self.backend.get_page_table_buffer()
-            self.page_table = page_buffer[self.infer_state.microbatch_index][
-                : att_batch_size * model.graph_max_len_in_batch
-            ].reshape(att_batch_size, model.graph_max_len_in_batch)
-        else:
-            self.page_table = torch.empty(
-                (att_batch_size, self.infer_state.max_kv_seq_len),
-                dtype=torch.int32,
-                device=self.infer_state.input_ids.device,
-            )
+        self.page_table = self.backend.get_page_table_view(
+            att_batch_size=att_batch_size,
+            microbatch_index=self.infer_state.microbatch_index,
+        )
 
         page_table_copy(
             page_table=self.page_table[:, : self.infer_state.max_kv_seq_len],

--- a/lightllm/server/router/model_infer/mode_backend/chunked_prefill/impl.py
+++ b/lightllm/server/router/model_infer/mode_backend/chunked_prefill/impl.py
@@ -49,6 +49,7 @@ class ChunkedPrefillBackend(ModeBackend):
         )
         return
 
+    @torch.inference_mode(mode=True)
     def infer_loop(self):
         torch.cuda.set_device(get_current_device_id())
         try:


### PR DESCRIPTION
## Summary
- size FA3 page-table storage from running request capacity, MTP width, and maximum sequence length
- reuse the same fixed buffer for CUDA Graph and eager decode paths
- share the implementation across FP, FP8, and MLA FA3 backends
