### PR TITLE
feat(logging): label prefill and decode node logs

### DIFF
--- a/lightllm/server/api_server.py
+++ b/lightllm/server/api_server.py
@@ -1,12 +1,13 @@
 import torch
 from .api_cli import add_cli_args
 from lightllm.server.core.objs.start_args_type import StartArgs
-from lightllm.utils.log_utils import init_logger
+from lightllm.utils.log_utils import init_logger, set_log_node_role
 
 logger = init_logger(__name__)
 
 
 def launch_server(args: StartArgs):
+    set_log_node_role(args.run_mode)
     from .api_start import pd_master_start, normal_or_p_d_start, config_server_start, visual_only_start
 
     try:

--- a/lightllm/utils/log_utils.py
+++ b/lightllm/utils/log_utils.py
@@ -7,12 +7,28 @@ import os
 import time
 from typing import Optional
 
-_FORMAT = "%(levelname)s %(asctime)s [%(filename)s:%(lineno)d] %(message)s"
+_FORMAT = "%(levelname)s %(asctime)s %(node_role)s[%(filename)s:%(lineno)d] %(message)s"
 _DATE_FORMAT = "%m-%d %H:%M:%S"
 
 _LOG_LEVEL = os.environ.get("LIGHTLLM_LOG_LEVEL", "debug")
 _LOG_LEVEL = getattr(logging, _LOG_LEVEL.upper(), 0)
 _LOG_DIR = os.environ.get("LIGHTLLM_LOG_DIR", None)
+_LOG_NODE_ROLE = os.environ.get("LIGHTLLM_LOG_NODE_ROLE", "")
+
+_PD_NODE_ROLE_MARKERS = {
+    "prefill": "P",
+    "decode": "D",
+}
+
+
+def set_log_node_role(run_mode: str):
+    """Add a P/D marker to logs and propagate it to child processes."""
+    global _LOG_NODE_ROLE
+    _LOG_NODE_ROLE = _PD_NODE_ROLE_MARKERS.get(run_mode, "")
+    if _LOG_NODE_ROLE:
+        os.environ["LIGHTLLM_LOG_NODE_ROLE"] = _LOG_NODE_ROLE
+    else:
+        os.environ.pop("LIGHTLLM_LOG_NODE_ROLE", None)
 
 
 class NewLineFormatter(logging.Formatter):
@@ -22,6 +38,7 @@ class NewLineFormatter(logging.Formatter):
         logging.Formatter.__init__(self, fmt, datefmt)
 
     def format(self, record):
+        record.node_role = f"[{_LOG_NODE_ROLE}] " if _LOG_NODE_ROLE else ""
         msg = logging.Formatter.format(self, record)
         if record.message != "":
             parts = msg.split(record.message)

--- a/unit_tests/utils/test_log_utils.py
+++ b/unit_tests/utils/test_log_utils.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+
+from lightllm.utils import log_utils
+
+
+def _format_message(message: str) -> str:
+    formatter = log_utils.NewLineFormatter("%(node_role)s%(message)s")
+    record = logging.LogRecord("test", logging.INFO, __file__, 1, message, (), None)
+    return formatter.format(record)
+
+
+@pytest.mark.parametrize(
+    ("run_mode", "expected_marker"),
+    [
+        ("prefill", "P"),
+        ("decode", "D"),
+        ("normal", ""),
+        ("pd_master", ""),
+    ],
+)
+def test_log_node_role_marker_is_limited_to_pd_workers(monkeypatch, run_mode, expected_marker):
+    monkeypatch.delenv("LIGHTLLM_LOG_NODE_ROLE", raising=False)
+    monkeypatch.setattr(log_utils, "_LOG_NODE_ROLE", "")
+
+    log_utils.set_log_node_role(run_mode)
+
+    formatted_marker = f"[{expected_marker}] " if expected_marker else ""
+    assert _format_message("ready") == f"{formatted_marker}ready"
+    if expected_marker:
+        assert log_utils.os.environ["LIGHTLLM_LOG_NODE_ROLE"] == expected_marker
+    else:
+        assert "LIGHTLLM_LOG_NODE_ROLE" not in log_utils.os.environ
+
+
+def test_log_node_role_marker_is_applied_to_every_line(monkeypatch):
+    monkeypatch.delenv("LIGHTLLM_LOG_NODE_ROLE", raising=False)
+    monkeypatch.setattr(log_utils, "_LOG_NODE_ROLE", "")
+    log_utils.set_log_node_role("prefill")
+
+    assert _format_message("first\nsecond") == "[P] first\r\n[P] second"


### PR DESCRIPTION
## Summary

- prefix prefill-node logs with `[P]` and decode-node logs with `[D]`
- propagate the role marker through the environment so multiprocessing and Hypercorn child processes inherit it
- preserve the existing log format for normal, PD master, and other run modes

Example:

```text
INFO 08-25 15:51:30 [P] [model_rpc.py:123] ready
INFO 08-25 15:51:32 [D] [model_rpc.py:123] ready
```

## Tests

- `PYTHONPATH=. pytest -q unit_tests/utils/test_log_utils.py unit_tests/server/test_pd_master_mode.py unit_tests/utils/test_start_utils.py` (33 passed)
- `pre-commit run --files lightllm/utils/log_utils.py lightllm/server/api_server.py unit_tests/utils/test_log_utils.py`