### PR TITLE
fix(pd): allow MTP Prefill nodes to disable CUDA graphs

### DIFF
--- a/deploy_dspark_1p1d.sh
+++ b/deploy_dspark_1p1d.sh
@@ -10,7 +10,8 @@ CPU_CACHE_SIZE="${CPU_CACHE_SIZE:-600}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-${MODEL_DIR}/chat_template.jinja}"
 PD_MASTER_IP="${PD_MASTER_IP:-127.0.0.1}"
 
-# DSpark checkpoint block_size. Prefill and decode must use the same value.
+# Decode speculative width. Prefill only builds/transfers draft KV and does not
+# need this decode-only setting.
 MTP_STEP="${MTP_STEP:-5}"
 
 # DSpark expands each logical decode request into speculative verification rows.
@@ -54,7 +55,6 @@ P_COMMON_ARGS=(
   --quant_type fp8w8a8-pt-sgl
   --mtp_mode dspark
   --mtp_draft_model_dir "${DRAFT_MODEL_DIR}"
-  --mtp_step "${MTP_STEP}"
   --chat_template "${CHAT_TEMPLATE}"
   --pd_trans_mode nixl
   --pd_kv_page_size 4096
@@ -109,6 +109,7 @@ start_prefill() {
     python -m lightllm.server.api_server \
       "${P_COMMON_ARGS[@]}" \
       --run_mode prefill \
+      --disable_cudagraph \
       --enable_cpu_cache \
       --cpu_cache_storage_size "${CPU_CACHE_SIZE}" \
       --tp 4 \

--- a/deploy_dspark_1p1d.sh
+++ b/deploy_dspark_1p1d.sh
@@ -10,8 +10,7 @@ CPU_CACHE_SIZE="${CPU_CACHE_SIZE:-600}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-${MODEL_DIR}/chat_template.jinja}"
 PD_MASTER_IP="${PD_MASTER_IP:-127.0.0.1}"
 
-# Decode speculative width. Prefill only builds/transfers draft KV and does not
-# need this decode-only setting.
+# DSpark checkpoint block_size. Prefill and decode must use the same value.
 MTP_STEP="${MTP_STEP:-5}"
 
 # DSpark expands each logical decode request into speculative verification rows.
@@ -55,6 +54,7 @@ P_COMMON_ARGS=(
   --quant_type fp8w8a8-pt-sgl
   --mtp_mode dspark
   --mtp_draft_model_dir "${DRAFT_MODEL_DIR}"
+  --mtp_step "${MTP_STEP}"
   --chat_template "${CHAT_TEMPLATE}"
   --pd_trans_mode nixl
   --pd_kv_page_size 4096

--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -37,7 +37,9 @@ def _launch_subprocesses(args: StartArgs):
     _set_envs_and_config(args)
 
     if args.mtp_mode is not None:
-        assert not args.disable_cudagraph, "--disable_cudagraph is not supported when --mtp_mode is enabled"
+        assert (
+            not args.disable_cudagraph or args.run_mode == "prefill"
+        ), "--disable_cudagraph is only supported on Prefill nodes when --mtp_mode is enabled"
 
     auto_set_max_req_total_len(args)
     auto_set_fused_shared_experts(args)
@@ -173,7 +175,9 @@ def _launch_subprocesses(args: StartArgs):
                 "dflash",
             ), f"--mtp_draft_model_dir is required for {args.mtp_mode} mode"
             args.mtp_draft_model_dir = [args.model_dir] * args.mtp_step
-        assert args.mtp_step > 0
+        assert args.mtp_step > 0 or (
+            args.mtp_step == 0 and args.run_mode == "prefill" and args.mtp_mode in ("dspark", "dflash")
+        )
     else:
         assert args.mtp_draft_model_dir is None
         assert args.mtp_step == 0

--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -175,9 +175,7 @@ def _launch_subprocesses(args: StartArgs):
                 "dflash",
             ), f"--mtp_draft_model_dir is required for {args.mtp_mode} mode"
             args.mtp_draft_model_dir = [args.model_dir] * args.mtp_step
-        assert args.mtp_step > 0 or (
-            args.mtp_step == 0 and args.run_mode == "prefill" and args.mtp_mode in ("dspark", "dflash")
-        )
+        assert args.mtp_step > 0
     else:
         assert args.mtp_draft_model_dir is None
         assert args.mtp_step == 0

--- a/test/start_scripts/qwen35/qwen35_pd_1p1d.sh
+++ b/test/start_scripts/qwen35/qwen35_pd_1p1d.sh
@@ -40,6 +40,7 @@ P_COMMON_ARGS=(
   --quant_type fp8w8a8-pt-sgl
   --mtp_mode dspark
   --mtp_draft_model_dir "${DSPARK_MODEL_DIR}"
+  --mtp_step 5
   "${CHAT_TEMPLATE_ARGS[@]}"
   --pd_trans_mode nccl
   --pd_kv_page_size 4096

--- a/test/start_scripts/qwen35/qwen35_pd_1p1d.sh
+++ b/test/start_scripts/qwen35/qwen35_pd_1p1d.sh
@@ -40,7 +40,6 @@ P_COMMON_ARGS=(
   --quant_type fp8w8a8-pt-sgl
   --mtp_mode dspark
   --mtp_draft_model_dir "${DSPARK_MODEL_DIR}"
-  --mtp_step 5
   "${CHAT_TEMPLATE_ARGS[@]}"
   --pd_trans_mode nccl
   --pd_kv_page_size 4096
@@ -84,6 +83,7 @@ trap 'exit 143' TERM
 CUDA_VISIBLE_DEVICES=0,1,2,3 python -m lightllm.server.api_server \
   "${P_COMMON_ARGS[@]}" \
   --run_mode prefill \
+  --disable_cudagraph \
   --enable_cpu_cache \
   --cpu_cache_storage_size "${CPU_CACHE_SIZE}" \
   --tp 4 \

--- a/unit_tests/server/test_mtp_start_args.py
+++ b/unit_tests/server/test_mtp_start_args.py
@@ -10,3 +10,23 @@ def test_mtp_requires_cuda_graph(monkeypatch):
 
     with pytest.raises(AssertionError, match="only supported on Prefill nodes"):
         _launch_subprocesses(args)
+
+
+def test_mtp_prefill_still_requires_positive_step(monkeypatch):
+    monkeypatch.setattr("lightllm.server.api_start._set_envs_and_config", lambda args: None)
+    monkeypatch.setattr("lightllm.server.api_start.auto_set_max_req_total_len", lambda args: None)
+    monkeypatch.setattr("lightllm.server.api_start.auto_set_fused_shared_experts", lambda args: None)
+    monkeypatch.setattr("lightllm.server.api_start.set_unique_server_name", lambda args: None)
+    args = StartArgs(
+        run_mode="prefill",
+        mtp_mode="dspark",
+        mtp_draft_model_dir=["draft"],
+        mtp_step=0,
+        disable_cudagraph=True,
+        disable_vision=True,
+        disable_audio=True,
+        disable_shm_warning=True,
+    )
+
+    with pytest.raises(AssertionError):
+        _launch_subprocesses(args)

--- a/unit_tests/server/test_mtp_start_args.py
+++ b/unit_tests/server/test_mtp_start_args.py
@@ -8,5 +8,5 @@ def test_mtp_requires_cuda_graph(monkeypatch):
     monkeypatch.setattr("lightllm.server.api_start._set_envs_and_config", lambda args: None)
     args = StartArgs(mtp_mode="vanilla_no_att", disable_cudagraph=True)
 
-    with pytest.raises(AssertionError, match="--disable_cudagraph is not supported"):
+    with pytest.raises(AssertionError, match="only supported on Prefill nodes"):
         _launch_subprocesses(args)


### PR DESCRIPTION
## Summary
- allow MTP Prefill nodes to disable CUDA graphs
- keep a positive, matching `mtp_step` on Prefill and Decode so draft KV/cache layouts remain consistent
- update the 1P1D DSpark launch scripts so Prefill uses `--disable_cudagraph` without dropping `mtp_step`

## Validation
- `python -m pytest -q unit_tests/server/test_mtp_start_args.py` (2 passed)
- `python -m compileall -q lightllm/server/api_start.py`
- `bash -n deploy_dspark_1p1d.sh`
- `bash -n test/start_scripts/qwen35/qwen35_pd_1p1d.sh`
- pre-commit: Black and flake8
