### PR TITLE
fix(pd): allow disabling MTP CUDA graphs on prefill

### DIFF
--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -36,7 +36,9 @@ def _set_envs_and_config(args: StartArgs):
 def _launch_subprocesses(args: StartArgs):
     _set_envs_and_config(args)
 
-    if args.mtp_mode is not None:
+    # Prefill-only PD nodes never run the MTP decode planner and therefore do not
+    # require decode CUDA Graphs.
+    if args.mtp_mode is not None and args.run_mode != "prefill":
         assert not args.disable_cudagraph, "--disable_cudagraph is not supported when --mtp_mode is enabled"
 
     auto_set_max_req_total_len(args)

--- a/unit_tests/server/test_mtp_start_args.py
+++ b/unit_tests/server/test_mtp_start_args.py
@@ -4,9 +4,30 @@ from lightllm.server.api_start import _launch_subprocesses
 from lightllm.server.core.objs.start_args_type import StartArgs
 
 
-def test_mtp_requires_cuda_graph(monkeypatch):
+@pytest.mark.parametrize("run_mode", ["normal", "decode"])
+def test_mtp_requires_cuda_graph_outside_prefill(monkeypatch, run_mode):
     monkeypatch.setattr("lightllm.server.api_start._set_envs_and_config", lambda args: None)
-    args = StartArgs(mtp_mode="vanilla_no_att", disable_cudagraph=True)
+    args = StartArgs(run_mode=run_mode, mtp_mode="vanilla_no_att", disable_cudagraph=True)
 
     with pytest.raises(AssertionError, match="--disable_cudagraph is not supported"):
+        _launch_subprocesses(args)
+
+
+def test_mtp_prefill_allows_disabling_cuda_graph(monkeypatch):
+    class ValidationPassed(Exception):
+        pass
+
+    def stop_after_mtp_validation(_args):
+        raise ValidationPassed
+
+    monkeypatch.setattr("lightllm.server.api_start._set_envs_and_config", lambda args: None)
+    monkeypatch.setattr("lightllm.server.api_start.auto_set_max_req_total_len", stop_after_mtp_validation)
+    args = StartArgs(
+        run_mode="prefill",
+        mtp_mode="dspark",
+        mtp_step=1,
+        disable_cudagraph=True,
+    )
+
+    with pytest.raises(ValidationPassed):
         _launch_subprocesses(args)


### PR DESCRIPTION
## Summary

- allow prefill-only PD nodes with MTP enabled to explicitly disable CUDA Graphs
- keep CUDA Graphs mandatory for normal and decode modes, where MTP planners depend on captured graph costs/layouts
- cover the DSpark prefill configuration with mtp_step=1 and disable_cudagraph enabled

## Problem

The startup validation currently rejects disable_cudagraph for every MTP process. Prefill-only PD nodes never execute the MTP decode planner, but still initialize decode CUDA Graphs. For a DSpark prefill node whose mtp_step differs from the draft checkpoint block_size, the unnecessary draft decode graph warmup reaches the DSpark post layer and fails while reshaping the padded batch into fixed-size blocks.

Allowing prefill-only nodes to disable CUDA Graphs avoids that unused decode initialization while preserving the requirement for all modes that perform speculative decoding.

## Testing

- PYTHONPATH=. pytest -q unit_tests/server/test_mtp_start_args.py unit_tests/common/basemodel/test_mtp_manager.py unit_tests/models/test_qwen3_dspark_model_output.py unit_tests/server/router/model_infer/mtp_speculative/test_dspark.py
  - 48 passed
- pre-commit run --files lightllm/server/api_start.py unit_tests/server/test_mtp_start_args.py
  - black passed
  - flake8 passed