### PR TITLE
fix(dspark): align block draft width with MTP step

### DIFF
--- a/lightllm/models/qwen3_dflash/model.py
+++ b/lightllm/models/qwen3_dflash/model.py
@@ -41,6 +41,9 @@ class Qwen3DFlashModel(LlamaTpPartModel):
         super()._verify_params()
         assert not self.enable_tpsp_mix_mode, "Qwen3 DFlash draft model does not support TP-SP"
 
+        assert self.args.mtp_step <= self.config["block_size"]
+        self.config["block_size"] = self.args.mtp_step
+
     def _init_custom(self):
         self._cos_cached = self.main_model._cos_cached
         self._sin_cached = self.main_model._sin_cached

--- a/unit_tests/models/test_qwen3_dspark_model_output.py
+++ b/unit_tests/models/test_qwen3_dspark_model_output.py
@@ -13,6 +13,31 @@ from lightllm.models.qwen3_dflash.model import Qwen3DFlashModel
 from lightllm.models.qwen3_dspark.layer_weights import pre_and_post_layer_weight as dspark_pre_post_weight
 from lightllm.models.qwen3_dspark.layer_infer.post_layer_infer import Qwen3DSparkPostLayerInfer
 from lightllm.models.qwen3_dspark.model import Qwen3DSparkModel
+from lightllm.models.llama.model import LlamaTpPartModel
+
+
+@pytest.mark.parametrize("mtp_step", [1, 5, 7])
+def test_parallel_block_runtime_width_follows_mtp_step(monkeypatch, mtp_step):
+    monkeypatch.setattr(LlamaTpPartModel, "_verify_params", lambda self: None)
+    model = Qwen3DFlashModel.__new__(Qwen3DFlashModel)
+    model.args = SimpleNamespace(mtp_mode="dspark", mtp_step=mtp_step)
+    model.config = {"block_size": 7}
+    model.enable_tpsp_mix_mode = False
+
+    model._verify_params()
+
+    assert model.config["block_size"] == mtp_step
+
+
+def test_parallel_block_rejects_mtp_step_above_checkpoint_capacity(monkeypatch):
+    monkeypatch.setattr(LlamaTpPartModel, "_verify_params", lambda self: None)
+    model = Qwen3DFlashModel.__new__(Qwen3DFlashModel)
+    model.args = SimpleNamespace(mtp_mode="dflash", mtp_step=8)
+    model.config = {"block_size": 7}
+    model.enable_tpsp_mix_mode = False
+
+    with pytest.raises(AssertionError):
+        model._verify_params()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- use `--mtp_step` as the runtime block width for DSpark and DFlash
- keep the checkpoint `block_size` as the supported upper bound
- reject `mtp_step` values larger than the checkpoint capacity before model initialization continues

With `mtp_step=5` and checkpoint `block_size=7`, proposer, FA3 attention, CUDA Graph, and DSpark post-layer now all use width 5.

## Tests
- `51 passed` across DSpark/DFlash model, MTP manager, and proposer tests
- pre-commit Black and flake8 passed