### PR TITLE
fix(pd): ignore transient router descendants in supervisor

### DIFF
--- a/lightllm/utils/start_utils.py
+++ b/lightllm/utils/start_utils.py
@@ -49,10 +49,24 @@ class SubmoduleManager:
         return processes
 
     def register_process_tree(self, root_process):
-        """Add all current descendants of a managed process to supervision."""
-        descendants = root_process.children(recursive=True)
-        self.processes.extend(descendants)
-        self.process_names.update((process, process.name()) for process in descendants)
+        """Add persistent LightLLM descendants to supervision.
+
+        A managed process may create short-lived helper processes while loading
+        models or compiling kernels. Those helpers retain a generic process name,
+        while persistent LightLLM services set a ``lightllm::`` process title.
+        """
+        for process in root_process.children(recursive=True):
+            try:
+                process_name = process.name()
+            except (psutil.NoSuchProcess, psutil.ZombieProcess):
+                # A short-lived child may exit while the process tree is scanned.
+                continue
+
+            if not process_name.startswith("lightllm::"):
+                continue
+
+            self.processes.append(process)
+            self.process_names[process] = process_name
 
     def terminate_all_processes(self):
         from lightllm.utils.envs_utils import get_env_start_args

--- a/unit_tests/utils/test_start_utils.py
+++ b/unit_tests/utils/test_start_utils.py
@@ -87,9 +87,9 @@ def test_start_submodule_processes_returns_and_manages_psutil_processes(monkeypa
 
 def test_register_process_tree_adds_recursive_descendants():
     descendants = [
-        FakeProcess(pid=1001, name="model_infer"),
-        FakeProcess(pid=1002, name="pd_manager"),
-        FakeProcess(pid=1003, name="pd_worker"),
+        FakeProcess(pid=1001, name="lightllm::model_infer"),
+        FakeProcess(pid=1002, name="lightllm::pd_manager"),
+        FakeProcess(pid=1003, name="lightllm::pd_worker"),
     ]
     router_process = FakeProcess(pid=1000, children=descendants)
     process_manager = start_utils.SubmoduleManager()
@@ -98,10 +98,41 @@ def test_register_process_tree_adds_recursive_descendants():
 
     assert process_manager.processes == descendants
     assert process_manager.process_names == {
-        descendants[0]: "model_infer",
-        descendants[1]: "pd_manager",
-        descendants[2]: "pd_worker",
+        descendants[0]: "lightllm::model_infer",
+        descendants[1]: "lightllm::pd_manager",
+        descendants[2]: "lightllm::pd_worker",
     }
+
+
+def test_register_process_tree_filters_short_lived_helper_processes():
+    model_process = FakeProcess(pid=1001, name="lightllm::model_infer")
+    compile_worker = FakeProcess(pid=1002, name="python")
+    pd_process = FakeProcess(pid=1003, name="lightllm::decode_trans")
+    router_process = FakeProcess(pid=1000, children=[model_process, compile_worker, pd_process])
+    process_manager = start_utils.SubmoduleManager()
+
+    process_manager.register_process_tree(router_process)
+
+    assert process_manager.processes == [model_process, pd_process]
+    assert process_manager.process_names == {
+        model_process: "lightllm::model_infer",
+        pd_process: "lightllm::decode_trans",
+    }
+
+
+def test_register_process_tree_ignores_processes_that_exit_during_scan():
+    class ExitedProcess(FakeProcess):
+        def name(self):
+            raise start_utils.psutil.NoSuchProcess(self.pid)
+
+    exited_process = ExitedProcess(pid=1001)
+    router_process = FakeProcess(pid=1000, children=[exited_process])
+    process_manager = start_utils.SubmoduleManager()
+
+    process_manager.register_process_tree(router_process)
+
+    assert process_manager.processes == []
+    assert process_manager.process_names == {}
 
 
 def test_setup_signal_handlers_registers_and_handles_sigterm(monkeypatch):


### PR DESCRIPTION
## Summary
- supervise only router descendants whose process title starts with `lightllm::`
- ignore short-lived Python helper processes that may exit normally after model startup
- tolerate descendants exiting while the process tree is being scanned