### PR TITLE
fix: filter zombie/dead processes in register_process_tree

### DIFF
--- a/lightllm/utils/start_utils.py
+++ b/lightllm/utils/start_utils.py
@@ -65,6 +65,9 @@ class SubmoduleManager:
             if not process_name.startswith("lightllm::"):
                 continue
 
+            if not process.is_running() or not is_process_active(process.pid):
+                continue
+
             self.processes.append(process)
             self.process_names[process] = process_name
 


### PR DESCRIPTION
Skip processes that are no longer active before adding them to the supervision list. This prevents zombie or already-exited processes from entering self.processes and avoids ineffective terminate_all_processes calls later.