### PR TITLE
fix: setup.py python_requires stale at >=3.9.16, docs require 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Operating System :: Linux",
     ],
-    python_requires=">=3.9.16",
+    python_requires=">=3.10",
     install_requires=[
         "pyzmq",
         "uvloop",


### PR DESCRIPTION
Fixes part of #1179.

The installation docs (`docs/EN/source/getting_started/installation.rst`) require Python 3.10, but `setup.py`'s `python_requires` still said `>=3.9.16`. This lets `pip install` proceed on Python 3.9 and fail deep inside dependency resolution (e.g. `flashinfer-python` requiring >=3.10) instead of surfacing a clear "Python >=3.10 required" error immediately.

Note: the `sgl-kernel==0.3.7.post1` version-pin issue also reported in #1179 appears to already be resolved on `main` (now `sglang-kernel==0.4.2.post1`), so this PR addresses the remaining root cause: the stale `python_requires` metadata.

## Test plan
- Confirmed current docs state Python 3.10 as the requirement (both the general requirements section and the `conda create -n lightllm python=3.10` example).
- Confirmed `setup.py` was out of sync (`>=3.9.16`) with that documented requirement.
- One-line change, no other logic affected.
