### PR TITLE
docs: CONTRIBUTING.md references yapf/Google style guide, but pre-commit actually runs black + flake8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,7 @@
 
 ### Coding Style Guide
 
-In general, we adhere to [Google Python style guide](https://google.github.io/styleguide/pyguide.html), and we recommend to use `yapf` to format your code.
-
-In this project, we adopted `pre-commit` to automatic check the code style.
+This project uses [`black`](https://github.com/psf/black) (line length 120) and `flake8` for code style. Both are run automatically via `pre-commit` (see `.pre-commit-config.yaml` for the exact configuration).
 
 To begin with, you should follow the step below to install `pre-commit`.
 


### PR DESCRIPTION
## What's wrong

`CONTRIBUTING.md` tells contributors to follow the Google Python style guide and format code with `yapf`. But `.pre-commit-config.yaml` only configures `black` (line-length 120) and `flake8` — there's no `yapf` config anywhere else in the repo. This is stale documentation, presumably left over from before the project switched formatters.

A new contributor following CONTRIBUTING.md as written would install/run the wrong tool (`yapf`) and could still fail the actual `pre-commit` check, which runs `black`.

## What this changes

Updates the "Coding Style Guide" section of `CONTRIBUTING.md` to name the tools that are actually enforced (`black`, `flake8`), matching `.pre-commit-config.yaml`. No functional/code changes.

## Test plan
- Compared `CONTRIBUTING.md` against `.pre-commit-config.yaml`; confirmed `black` + `flake8` are the only formatters configured repo-wide.
- Searched the repo for any `yapf` config (`.style.yapf`, etc.) — none found outside the doc text being changed.
