### PR TITLE
fix(pd): guard remote_agents dict with a lock to fix NIXL concurrent-add race (GH-1470)

### DIFF
--- a/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
+++ b/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
@@ -1,6 +1,7 @@
 import pickle
 import copy
 import os
+import threading
 import time
 from dataclasses import dataclass
 from typing import Dict
@@ -40,6 +41,10 @@ class NixlKVTransporter:
         self.nixl_agent = NixlWrapper(self.agent_name, conf)
         self._register_kv_move_buffer(kv_move_buffer=kv_move_buffer)
         self.remote_agents: Dict[str, PDAgentMetadata] = {}
+        # remote_agents is read and mutated from several worker threads (recv, dispatch,
+        # accept_peer, request/ready page loops, ...), so every access needs to go through
+        # this lock to avoid concurrent add/remove races on the same peer (see GH-1470).
+        self._remote_agents_lock = threading.Lock()
         return
 
     @property
@@ -73,36 +78,38 @@ class NixlKVTransporter:
         return self.nixl_agent.prep_xfer_dlist(agent_name, descs, "VRAM")
 
     def connect_add_remote_agent(self, remote_agent: PDAgentMetadata):
-        if remote_agent.agent_name in self.remote_agents:
-            return
+        with self._remote_agents_lock:
+            if remote_agent.agent_name in self.remote_agents:
+                return
 
-        start_time = time.time()
+            start_time = time.time()
 
-        peer_name = self.nixl_agent.add_remote_agent(remote_agent.agent_metadata)
-        if isinstance(peer_name, bytes):
-            peer_name = peer_name.decode()
+            peer_name = self.nixl_agent.add_remote_agent(remote_agent.agent_metadata)
+            if isinstance(peer_name, bytes):
+                peer_name = peer_name.decode()
 
-        assert (
-            peer_name == remote_agent.agent_name
-        ), f"Peer name {peer_name} does not match remote name {remote_agent.agent_name}"
+            assert (
+                peer_name == remote_agent.agent_name
+            ), f"Peer name {peer_name} does not match remote name {remote_agent.agent_name}"
 
-        page_mem_desc = self.nixl_agent.deserialize_descs(remote_agent.page_reg_desc)
-        kv_page_xfer_handles = self._create_paged_xfer_handles(
-            page_mem_desc, remote_agent.num_pages, agent_name=peer_name
-        )
-        remote_agent.page_xfer_handles = kv_page_xfer_handles
+            page_mem_desc = self.nixl_agent.deserialize_descs(remote_agent.page_reg_desc)
+            kv_page_xfer_handles = self._create_paged_xfer_handles(
+                page_mem_desc, remote_agent.num_pages, agent_name=peer_name
+            )
+            remote_agent.page_xfer_handles = kv_page_xfer_handles
 
-        logger.info(
-            f"Added remote agent {peer_name} with mem desc {page_mem_desc} cost time: {time.time() - start_time} s"
-        )
+            logger.info(
+                f"Added remote agent {peer_name} with mem desc {page_mem_desc} cost time: {time.time() - start_time} s"
+            )
 
-        self.remote_agents[remote_agent.agent_name] = remote_agent
+            self.remote_agents[remote_agent.agent_name] = remote_agent
         return
 
     def remove_remote_agent(self, peer_name: str):
-        if peer_name in self.remote_agents:
+        with self._remote_agents_lock:
+            remote_agent: PDAgentMetadata = self.remote_agents.pop(peer_name, None)
+        if remote_agent is not None:
             try:
-                remote_agent: PDAgentMetadata = self.remote_agents.pop(peer_name, None)
                 assert remote_agent.agent_name == peer_name
                 self.nixl_agent.remove_remote_agent(remote_agent.agent_name)
                 if remote_agent.page_xfer_handles is not None:

--- a/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
+++ b/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
@@ -108,13 +108,17 @@ class NixlKVTransporter:
         with self._remote_agents_lock:
             remote_agent: PDAgentMetadata = self.remote_agents.pop(peer_name, None)
             if remote_agent is not None:
+                start_time = time.monotonic()
                 try:
                     assert remote_agent.agent_name == peer_name
                     self.nixl_agent.remove_remote_agent(remote_agent.agent_name)
                     if remote_agent.page_xfer_handles is not None:
                         self.nixl_agent.release_dlist_handle(remote_agent.page_xfer_handles)
+                    logger.info(f"Removed remote agent {peer_name}, cost time: {time.monotonic() - start_time:.6f} s")
                 except BaseException as e:
-                    logger.error(f"remove remote agent {peer_name} failed")
+                    logger.error(
+                        f"remove remote agent {peer_name} failed, cost time: {time.monotonic() - start_time:.6f} s"
+                    )
                     logger.exception(str(e))
             else:
                 logger.warning(f"try to remove remote agent, but peer name {peer_name} agent did not exist")

--- a/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
+++ b/lightllm/server/router/model_infer/mode_backend/pd/nixl_kv_transporter.py
@@ -41,9 +41,8 @@ class NixlKVTransporter:
         self.nixl_agent = NixlWrapper(self.agent_name, conf)
         self._register_kv_move_buffer(kv_move_buffer=kv_move_buffer)
         self.remote_agents: Dict[str, PDAgentMetadata] = {}
-        # remote_agents is read and mutated from several worker threads (recv, dispatch,
-        # accept_peer, request/ready page loops, ...), so every access needs to go through
-        # this lock to avoid concurrent add/remove races on the same peer (see GH-1470).
+        # Serialize complete peer add/remove operations, including native NIXL
+        # calls and descriptor cleanup, across worker threads (see GH-1470).
         self._remote_agents_lock = threading.Lock()
         return
 
@@ -108,17 +107,17 @@ class NixlKVTransporter:
     def remove_remote_agent(self, peer_name: str):
         with self._remote_agents_lock:
             remote_agent: PDAgentMetadata = self.remote_agents.pop(peer_name, None)
-        if remote_agent is not None:
-            try:
-                assert remote_agent.agent_name == peer_name
-                self.nixl_agent.remove_remote_agent(remote_agent.agent_name)
-                if remote_agent.page_xfer_handles is not None:
-                    self.nixl_agent.release_dlist_handle(remote_agent.page_xfer_handles)
-            except BaseException as e:
-                logger.error(f"remove remote agent {peer_name} failed")
-                logger.exception(str(e))
-        else:
-            logger.warning(f"try to remove remote agent, but peer name {peer_name} agent did not exist")
+            if remote_agent is not None:
+                try:
+                    assert remote_agent.agent_name == peer_name
+                    self.nixl_agent.remove_remote_agent(remote_agent.agent_name)
+                    if remote_agent.page_xfer_handles is not None:
+                        self.nixl_agent.release_dlist_handle(remote_agent.page_xfer_handles)
+                except BaseException as e:
+                    logger.error(f"remove remote agent {peer_name} failed")
+                    logger.exception(str(e))
+            else:
+                logger.warning(f"try to remove remote agent, but peer name {peer_name} agent did not exist")
 
     def send_write_done_task_to_decode_node(self, trans_task: PDChunckedTransTask):
         decode_agent_name = trans_task.decode_agent_name


### PR DESCRIPTION
`NixlKVTransporter.remote_agents` is a plain dict that several worker threads read and mutate concurrently on the same instance (`recv_task_loop`, `dispatch_task_loop`, `accept_peer_task_loop`, `request_page_loop`, `read_page_to_mems_loop`, `success_loop`, `fail_loop` are all started as separate daemon threads sharing one `transporter`).

`connect_add_remote_agent()` did an unlocked check-then-add:

```python
if remote_agent.agent_name in self.remote_agents:
    return
...
self.remote_agents[remote_agent.agent_name] = remote_agent
```

and `remove_remote_agent()` did an unlocked check-then-pop. Every `send_*` method also does an unlocked `if peer_name not in self.remote_agents: connect_add_remote_agent(...)`.

When a peer transiently disappears (e.g. after `NIXL_ERR_REMOTE_DISCONNECT` removes it), two threads can both observe it missing and both call `nixl_agent.add_remote_agent()` for the same peer at the same time. That double-add corrupts UCX endpoint state and aborts the NIXL progress thread with a `ud_ep.c` PSN assertion, which kills the KV-transfer process and takes down the whole PD router (see #1470 for the full failure timeline and stack trace).

## Fix

Add a `threading.Lock` to `NixlKVTransporter` and guard the full check-then-add sequence in `connect_add_remote_agent()` and the check-then-pop in `remove_remote_agent()` with it, so only one thread can add or remove a given peer at a time. The rest of the call sites' pre-checks (`if X not in self.remote_agents`) stay as cheap fast-path hints — correctness now comes from the lock inside `connect_add_remote_agent`, which re-checks membership once it holds the lock.

Fixes #1470

## Scope

Kept to the one file / one race described in the issue (`nixl_kv_transporter.py`). Did not touch the wider unlocked reads in `write_blocks_paged` etc. since those aren't the failure mode reported in #1470 and would be a separate, larger change.

## Verification

- `python -m py_compile` on the changed file.
- No NIXL/UCX hardware available in this environment to reproduce the multi-node race directly; the fix follows directly from the file's own logic (unguarded check-then-add/remove across threads that the class itself spawns) and matches the exact code path called out in the issue.
