### PR TITLE
fix(dp): wait forward before gather_req

### DIFF
--- a/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
+++ b/lightllm/server/router/model_infer/mode_backend/dp_backend/impl.py
@@ -130,6 +130,12 @@ class DPChunkedPrefillBackend(ModeBackend):
                     recover_paused=self.control_state_machine.try_recover_paused_reqs(),
                 )
 
+                if self.support_overlap:
+                    # The previous infer thread releases forward before its GPU work finishes.
+                    # Keep the next DP collective behind that work to avoid overlapping NCCL
+                    # with the previous DeepEP/MTP kernels.
+                    torch.cuda.current_stream().wait_stream(g_infer_context.get_overlap_stream())
+
                 dp_prefill_req_nums, dp_decode_req_nums = self._dp_all_gather_prefill_and_decode_req_num(
                     prefill_reqs=prefill_reqs, decode_reqs=decode_reqs
                 )


### PR DESCRIPTION
## Summary

- Serialize the next DP collective behind GPU work already queued on the previous overlap stream.
- Prevent NCCL all-gathers from overlapping outstanding DeepEP/MTP kernels.
- Preserve request-preparation overlap without adding a host-side synchronization.

## Root cause

With overlap enabled, the previous infer thread can release forward before its GPU work finishes. The next infer-loop iteration may then enqueue DP all-gathers on the current stream while the prior DeepEP/MTP kernels are still running. Adding an explicit stream dependency restores the required ordering.

This PR isolates the fix from `d5b04bf` onto the latest `main`; the resulting commit is `b98f6802`.

## Testing

- Focused mocked DP overlap-ordering regression test passed in the H100 LightLLM environment.
- Changed module passes Python byte-compilation.
- `git diff --check` passes.