### PR TITLE
fix(mtp): reserve page-table headroom for length finish

### DIFF
--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -149,7 +149,12 @@ class RouterManager(RouterMultiNodeTpHelper, RouterRlOpHelper, object):
             "load_way": self.load_way,
             "max_total_token_num": self.max_total_token_num,
             "max_req_num": self.args.running_max_req_size,
-            "max_seq_length": self.args.max_req_total_len + max(8, self.args.mtp_step * 2),
+            # MTP length stopping is asynchronous, so up to mtp_step - 1 accepted
+            # positions may already be committed when FINISHED_LENGTH is observed.
+            # The overlapped iteration then needs mtp_step positions for target
+            # verification and another mtp_step for the DSpark/DFlash draft block.
+            # Thus the page table needs 3 * mtp_step - 1 positions of MTP headroom.
+            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step - 1),
             "nccl_host": self.args.nccl_host,
             "nccl_port": get_shm_port_args().nccl_port,
             "is_first_token_constraint_mode": self.args.first_token_constraint_mode,

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -149,12 +149,12 @@ class RouterManager(RouterMultiNodeTpHelper, RouterRlOpHelper, object):
             "load_way": self.load_way,
             "max_total_token_num": self.max_total_token_num,
             "max_req_num": self.args.running_max_req_size,
-            # MTP length stopping is asynchronous, so up to mtp_step - 1 accepted
+            # MTP length stopping is asynchronous, so up to mtp_step accepted
             # positions may already be committed when FINISHED_LENGTH is observed.
             # The overlapped iteration then needs mtp_step positions for target
             # verification and another mtp_step for the DSpark/DFlash draft block.
-            # Thus the page table needs 3 * mtp_step - 1 positions of MTP headroom.
-            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step - 1),
+            # Thus the page table needs 3 * mtp_step positions of MTP headroom.
+            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step),
             "nccl_host": self.args.nccl_host,
             "nccl_port": get_shm_port_args().nccl_port,
             "is_first_token_constraint_mode": self.args.first_token_constraint_mode,

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -156,7 +156,7 @@ class RouterManager(RouterMultiNodeTpHelper, RouterRlOpHelper, object):
             # Thus the page table needs 3 * mtp_step positions of MTP headroom.
             # Keep eight additional positions as a safety margin for future overlap
             # changes while preserving the historical +8 for non-MTP runs.
-            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step + 8),
+            "max_seq_length": self.args.max_req_total_len + 3 * self.args.mtp_step + 8,
             "nccl_host": self.args.nccl_host,
             "nccl_port": get_shm_port_args().nccl_port,
             "is_first_token_constraint_mode": self.args.first_token_constraint_mode,

--- a/lightllm/server/router/manager.py
+++ b/lightllm/server/router/manager.py
@@ -154,7 +154,9 @@ class RouterManager(RouterMultiNodeTpHelper, RouterRlOpHelper, object):
             # The overlapped iteration then needs mtp_step positions for target
             # verification and another mtp_step for the DSpark/DFlash draft block.
             # Thus the page table needs 3 * mtp_step positions of MTP headroom.
-            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step),
+            # Keep eight additional positions as a safety margin for future overlap
+            # changes while preserving the historical +8 for non-MTP runs.
+            "max_seq_length": self.args.max_req_total_len + max(8, 3 * self.args.mtp_step + 8),
             "nccl_host": self.args.nccl_host,
             "nccl_port": get_shm_port_args().nccl_port,
             "is_first_token_constraint_mode": self.args.first_token_constraint_mode,


### PR DESCRIPTION
## Summary
- reserve the required `3 * mtp_step` MTP sequence headroom plus eight additional safety positions
- document the separate costs of delayed length finishing, target verification, and the next DSpark/DFlash draft block
- preserve the historical eight-position slack for non-MTP configurations

## Root cause
One MTP verify round can commit up to `mtp_step + 1` tokens. If only one output token remains, that token reaches `FINISHED_LENGTH`, while the other `mtp_step` positions may already be committed before the asynchronous finish status is consumed. The overlapped target verify and draft proposal require another `2 * mtp_step` positions, so the required FA3 page-table headroom is `3 * mtp_step`. An additional eight positions are retained as a safety margin for future overlap changes.

The configured capacity is therefore `max_req_total_len + 3 * mtp_step + 8`.

## Validation
- `git diff --check`
- `python -m py_compile lightllm/server/router/manager.py`

The local pre-commit hook could not run because `pre-commit` is not installed in the current environment.