### PR TITLE
perf: avoid full-vocab gather for greedy sampling

### DIFF
--- a/lightllm/common/basemodel/triton_kernel/post_process/greedy_sample.py
+++ b/lightllm/common/basemodel/triton_kernel/post_process/greedy_sample.py
@@ -1,0 +1,104 @@
+"""Local greedy statistics for distributed vocabulary shards."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _greedy_sample_stage1_kernel(
+    logits,
+    partial_max,
+    partial_sum,
+    partial_argmax,
+    stride_row,
+    stride_col,
+    vocab_size: tl.constexpr,
+    num_blocks: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    values = tl.load(
+        logits + row * stride_row + offsets * stride_col,
+        mask=offsets < vocab_size,
+        other=-float("inf"),
+    )
+    values = values.to(tl.float32)
+
+    block_max = tl.max(values, axis=0)
+    block_sum = tl.sum(tl.exp(values - block_max), axis=0)
+    block_argmax = tl.argmax(values, axis=0) + block * BLOCK_SIZE
+    output_offset = row * num_blocks + block
+    tl.store(partial_max + output_offset, block_max)
+    tl.store(partial_sum + output_offset, block_sum)
+    tl.store(partial_argmax + output_offset, block_argmax)
+
+
+@triton.jit
+def _greedy_sample_stage2_stats_kernel(
+    partial_max,
+    partial_sum,
+    partial_argmax,
+    output_stats,
+    num_blocks: tl.constexpr,
+    batch_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_blocks
+    input_offset = row * num_blocks + offsets
+    block_max = tl.load(partial_max + input_offset, mask=mask, other=-float("inf"))
+    block_sum = tl.load(partial_sum + input_offset, mask=mask, other=0.0)
+    block_argmax = tl.load(partial_argmax + input_offset, mask=mask, other=0x7FFFFFFF)
+
+    global_max = tl.max(block_max, axis=0)
+    global_sum = tl.sum(block_sum * tl.exp(block_max - global_max), axis=0)
+    candidate_ids = tl.where(block_max == global_max, block_argmax, 0x7FFFFFFF)
+    global_argmax = tl.min(candidate_ids, axis=0)
+    tl.store(output_stats + row, global_max)
+    tl.store(output_stats + batch_size + row, global_max + tl.log(global_sum))
+    tl.store(output_stats + 2 * batch_size + row, global_argmax)
+
+
+def _launch_stage1(logits: torch.Tensor, scratch: torch.Tensor, block_size: int, num_blocks: int) -> None:
+    batch_size, vocab_size = logits.shape
+    _greedy_sample_stage1_kernel[(batch_size, num_blocks)](
+        logits,
+        scratch[0],
+        scratch[1],
+        scratch[2],
+        logits.stride(0),
+        logits.stride(1),
+        vocab_size=vocab_size,
+        num_blocks=num_blocks,
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+    )
+
+
+@torch.no_grad()
+def greedy_sample_local_stats(logits: torch.Tensor, alloc_func=torch.empty) -> torch.Tensor:
+    """Return local max, logsumexp and argmax rows for distributed greedy sampling."""
+
+    assert logits.ndim == 2 and logits.is_cuda and logits.is_contiguous()
+    batch_size, vocab_size = logits.shape
+    block_size = 4096
+    num_blocks = triton.cdiv(vocab_size, block_size)
+    scratch = alloc_func((3, batch_size, num_blocks), dtype=torch.float32, device=logits.device)
+    output_stats = alloc_func((3, batch_size), dtype=torch.float32, device=logits.device)
+
+    _launch_stage1(logits, scratch, block_size, num_blocks)
+    _greedy_sample_stage2_stats_kernel[(batch_size,)](
+        scratch[0],
+        scratch[1],
+        scratch[2],
+        output_stats,
+        num_blocks=num_blocks,
+        batch_size=batch_size,
+        BLOCK_SIZE=triton.next_power_of_2(num_blocks),
+        num_warps=4,
+    )
+    return output_stats

--- a/lightllm/common/basemodel/triton_kernel/post_process/vocab_parallel_greedy.py
+++ b/lightllm/common/basemodel/triton_kernel/post_process/vocab_parallel_greedy.py
@@ -1,0 +1,119 @@
+"""Greedy sampling directly from tensor-parallel vocabulary shards."""
+
+import torch
+import triton
+import triton.language as tl
+
+from lightllm.common.basemodel.triton_kernel.post_process.greedy_sample import (
+    greedy_sample_local_stats,
+)
+from lightllm.common.basemodel.triton_kernel.transpose_convert import (
+    transpose_convert_2d,
+)
+from lightllm.distributed.communication_op import all_gather
+from lightllm.utils.envs_utils import enable_env_vars
+
+
+VOCAB_PARALLEL_GREEDY_ENV = "LIGHTLLM_VOCAB_PARALLEL_GREEDY"
+
+
+def is_vocab_parallel_greedy_enabled() -> bool:
+    return enable_env_vars(VOCAB_PARALLEL_GREEDY_ENV)
+
+
+@triton.jit
+def _combine_vocab_parallel_stats_kernel(
+    gathered_stats,
+    output,
+    token_num,
+    vocab_size: tl.constexpr,
+    tp_world_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    token_mask = token_offsets < token_num
+    rank_stride = 3 * token_num
+
+    global_max = tl.full((BLOCK_SIZE,), -float("inf"), tl.float32)
+    global_id = tl.full((BLOCK_SIZE,), 0x7FFFFFFF, tl.int32)
+    for rank in tl.static_range(tp_world_size):
+        rank_base = rank * rank_stride
+        local_max = tl.load(
+            gathered_stats + rank_base + token_offsets,
+            mask=token_mask,
+            other=-float("inf"),
+        )
+        local_id = tl.load(
+            gathered_stats + rank_base + 2 * token_num + token_offsets,
+            mask=token_mask,
+            other=0x7FFFFFFF,
+        ).to(tl.int32)
+        local_id += (rank * vocab_size) // tp_world_size
+        wins = (local_max > global_max) | ((local_max == global_max) & (local_id < global_id))
+        global_max = tl.where(wins, local_max, global_max)
+        global_id = tl.where(wins, local_id, global_id)
+
+    global_sum = tl.zeros((BLOCK_SIZE,), tl.float32)
+    for rank in tl.static_range(tp_world_size):
+        rank_base = rank * rank_stride
+        local_lse = tl.load(
+            gathered_stats + rank_base + token_num + token_offsets,
+            mask=token_mask,
+            other=-float("inf"),
+        )
+        global_sum += tl.exp(local_lse - global_max)
+
+    tl.store(output + token_offsets * 2, global_id, mask=token_mask)
+    tl.store(output + token_offsets * 2 + 1, -tl.log(global_sum), mask=token_mask)
+
+
+@torch.no_grad()
+def vocab_parallel_greedy(
+    local_logits: torch.Tensor,
+    *,
+    vocab_size: int,
+    tp_world_size: int,
+    group,
+    alloc_func,
+) -> torch.Tensor:
+    """Return packed ``[token_id, logprob]`` rows without gathering full logits."""
+
+    assert local_logits.ndim == 2 and local_logits.is_cuda and local_logits.is_contiguous()
+    local_vocab_size, token_num = local_logits.shape
+    assert local_vocab_size in {
+        vocab_size // tp_world_size,
+        (vocab_size + tp_world_size - 1) // tp_world_size,
+    }
+
+    transposed_logits = alloc_func(
+        (token_num, local_vocab_size),
+        dtype=local_logits.dtype,
+        device=local_logits.device,
+    )
+    transpose_convert_2d(local_logits, transposed_logits)
+    local_stats = greedy_sample_local_stats(transposed_logits, alloc_func=alloc_func)
+
+    gathered_stats = alloc_func((tp_world_size, 3, token_num), dtype=torch.float32, device=local_logits.device)
+    all_gather(
+        [gathered_stats[rank] for rank in range(tp_world_size)],
+        local_stats,
+        group=group,
+        async_op=False,
+    )
+
+    output = alloc_func((token_num, 2), dtype=torch.float32, device=local_logits.device)
+    _combine_vocab_parallel_stats_kernel[(triton.cdiv(token_num, 256),)](
+        gathered_stats,
+        output,
+        token_num,
+        vocab_size=vocab_size,
+        tp_world_size=tp_world_size,
+        BLOCK_SIZE=256,
+        num_warps=4,
+    )
+    return output
+
+
+def unpack_vocab_parallel_greedy(output: torch.Tensor):
+    assert output.ndim == 2 and output.shape[1] == 2 and output.dtype == torch.float32
+    return output[:, 0].to(torch.int64), output[:, 1]

--- a/lightllm/common/basemodel/triton_kernel/transpose_convert.py
+++ b/lightllm/common/basemodel/triton_kernel/transpose_convert.py
@@ -1,0 +1,65 @@
+"""Tiled transpose kernels used by the post-layer logits path."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _transpose_convert_2d_kernel(
+    input_ptr,
+    output_ptr,
+    rows,
+    cols,
+    input_stride_0,
+    input_stride_1,
+    output_stride_0,
+    output_stride_1,
+    BLOCK_ROWS: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+):
+    row_offsets = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    col_offsets = tl.program_id(1) * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+    input_offsets = row_offsets[:, None] * input_stride_0 + col_offsets[None, :] * input_stride_1
+    mask = (row_offsets[:, None] < rows) & (col_offsets[None, :] < cols)
+    values = tl.load(input_ptr + input_offsets, mask=mask)
+
+    output_offsets = col_offsets[:, None] * output_stride_0 + row_offsets[None, :] * output_stride_1
+    tl.store(output_ptr + output_offsets, tl.trans(values), mask=tl.trans(mask))
+
+
+@torch.no_grad()
+def transpose_convert_2d(
+    input_tensor: torch.Tensor,
+    output_tensor: torch.Tensor,
+    *,
+    block_rows: int = 64,
+    block_cols: int = 64,
+    num_warps: int = 8,
+    num_stages: int = 1,
+) -> torch.Tensor:
+    """Transpose a contiguous 2-D CUDA tensor while converting its dtype."""
+
+    assert input_tensor.is_cuda and output_tensor.is_cuda
+    assert input_tensor.device == output_tensor.device
+    assert input_tensor.ndim == 2 and output_tensor.ndim == 2
+    assert output_tensor.shape == (input_tensor.shape[1], input_tensor.shape[0])
+    assert input_tensor.is_contiguous() and output_tensor.is_contiguous()
+
+    rows, cols = input_tensor.shape
+    grid = (triton.cdiv(rows, block_rows), triton.cdiv(cols, block_cols))
+    _transpose_convert_2d_kernel[grid](
+        input_tensor,
+        output_tensor,
+        rows,
+        cols,
+        input_tensor.stride(0),
+        input_tensor.stride(1),
+        output_tensor.stride(0),
+        output_tensor.stride(1),
+        BLOCK_ROWS=block_rows,
+        BLOCK_COLS=block_cols,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return output_tensor

--- a/lightllm/models/llama/layer_infer/post_layer_infer.py
+++ b/lightllm/models/llama/layer_infer/post_layer_infer.py
@@ -7,6 +7,10 @@ from lightllm.common.basemodel.layer_weights.base_layer_weight import BaseLayerW
 from lightllm.models.llama.layer_weights.pre_and_post_layer_weight import LlamaPreAndPostLayerWeight
 from lightllm.models.llama.infer_struct import LlamaInferStateInfo
 from lightllm.common.basemodel import PostLayerInferTpl
+from lightllm.common.basemodel.triton_kernel.post_process.vocab_parallel_greedy import (
+    is_vocab_parallel_greedy_enabled,
+    vocab_parallel_greedy,
+)
 from lightllm.distributed.communication_op import all_gather
 
 
@@ -80,7 +84,7 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         if prompt_logics_hiddens is not None:
             prompt_token_num = prompt_logics_hiddens.shape[0]
             infer_state.prompt_logics = self._lm_head_and_gather(
-                prompt_logics_hiddens, prompt_token_num, layer_weight, infer_state
+                prompt_logics_hiddens, prompt_token_num, layer_weight, infer_state, force_full_logits=True
             )
 
         return ans_logics
@@ -91,6 +95,7 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         token_num: int,
         layer_weight: LlamaPreAndPostLayerWeight,
         infer_state: LlamaInferStateInfo,
+        force_full_logits: bool = False,
     ) -> torch.Tensor:
         normed = self._norm(hidden, infer_state, layer_weight)
         normed = normed.permute(1, 0).view(-1, token_num)
@@ -98,6 +103,15 @@ class LlamaPostLayerInfer(PostLayerInferTpl):
         normed = None
 
         vocab_size = layer_weight.lm_head_weight_.vocab_size
+        if is_vocab_parallel_greedy_enabled() and not force_full_logits:
+            return vocab_parallel_greedy(
+                logic_batch,
+                vocab_size=vocab_size,
+                tp_world_size=self.tp_world_size_,
+                group=infer_state.dist_group,
+                alloc_func=self.alloc_tensor,
+            )
+
         if self.tp_world_size_ == 1:
             gather_data = logic_batch
         else:

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -45,6 +45,10 @@ from lightllm.server.core.objs.shm_objs_io_buffer import ShmObjsIOBuffer
 from lightllm.server.router.model_infer.mode_backend.overlap_events import OverlapEventManager, OverlapEventPack
 from lightllm.server.router.model_infer.mode_backend.generic_post_process import sample
 from lightllm.common.basemodel.triton_kernel.gather_token_id import scatter_token
+from lightllm.common.basemodel.triton_kernel.post_process.vocab_parallel_greedy import (
+    is_vocab_parallel_greedy_enabled,
+    unpack_vocab_parallel_greedy,
+)
 from lightllm.server.pd_io_struct import PDChunckedTransTaskRet
 from .multi_level_kv_cache import MultiLevelKvCacheModule
 from lightllm.utils.profiler import ProcessProfiler, ProfilerCmd
@@ -383,6 +387,13 @@ class ModeBackend:
         仅 ``--enable_rl`` 时做真实 rank；否则返回 GPU 常量 ``-1``，避免 O(batch * vocab) 比较。
         下游 async_copy 在同样条件下会忽略该返回值。
         """
+        if is_vocab_parallel_greedy_enabled():
+            return g_pin_mem_manager.get_const_gpu_tensor(
+                key="next_token_ranks",
+                shape=next_token_ids.shape,
+                fill_value=1 if self.args.enable_rl else -1,
+                dtype=torch.int32,
+            )
         if not self.args.enable_rl:
             return g_pin_mem_manager.get_const_gpu_tensor(
                 key="next_token_ranks",
@@ -840,10 +851,16 @@ class ModeBackend:
 
     def _gen_argmax_token_ids(self, model_output: ModelOutput):
         logits = model_output.logits
+        if is_vocab_parallel_greedy_enabled():
+            token_ids, _ = unpack_vocab_parallel_greedy(logits)
+            return token_ids
         return torch.argmax(logits, dim=-1)
 
     def _gen_argmax_token_ids_and_prob(self, model_output: ModelOutput):
         logits = model_output.logits
+        if is_vocab_parallel_greedy_enabled():
+            token_ids, token_logprobs = unpack_vocab_parallel_greedy(logits)
+            return token_ids, torch.exp(token_logprobs)
         probs = torch.softmax(logits, dim=-1)
         max_probs, draft_next_token_ids_gpu = torch.max(probs, dim=-1)
         return draft_next_token_ids_gpu, max_probs
@@ -860,6 +877,8 @@ class ModeBackend:
     ):
 
         if mask_func is not None:
+            if is_vocab_parallel_greedy_enabled():
+                raise RuntimeError("LIGHTLLM_VOCAB_PARALLEL_GREEDY does not support constrained logits")
             assert len(run_reqs) == logits.shape[0]
             mask_func(run_reqs, logits)
 

--- a/lightllm/server/router/model_infer/mode_backend/generic_post_process.py
+++ b/lightllm/server/router/model_infer/mode_backend/generic_post_process.py
@@ -3,12 +3,45 @@ from typing import List, Tuple
 from lightllm.common.basemodel.triton_kernel.post_process.apply_penalty import apply_penalty
 from lightllm.common.basemodel.triton_kernel.post_process.apply_penalty_gpu_cache import apply_penalty_gpu_cache
 from lightllm.common.basemodel.triton_kernel.post_process.apply_invalid_token import apply_invalid_token_ids
+from lightllm.common.basemodel.triton_kernel.post_process.vocab_parallel_greedy import (
+    is_vocab_parallel_greedy_enabled,
+    unpack_vocab_parallel_greedy,
+)
 from lightllm.server.router.model_infer.infer_batch import InferReq, g_infer_context
 from lightllm.server.router.model_infer.pin_mem_manager import g_pin_mem_manager
 from lightllm.utils.envs_utils import get_env_start_args
 
 
+def _can_use_unmodified_greedy_logits(reqs: List[InferReq]) -> bool:
+    """Whether sampling is exactly argmax over the incoming logits."""
+
+    for req_obj in reqs:
+        sample_param = req_obj.sampling_param
+        shm_param = sample_param.shm_param
+        if shm_param.top_k != 1 or shm_param.temperature != 1.0:
+            return False
+        if (
+            shm_param.presence_penalty != 0.0
+            or shm_param.frequency_penalty != 0.0
+            or shm_param.repetition_penalty != 1.0
+        ):
+            return False
+        if shm_param.exponential_decay_length_penalty.to_tuple()[1] != 1.0:
+            return False
+        out_token_len = req_obj.get_cur_total_len() - req_obj.shm_req.input_len
+        if out_token_len < shm_param.min_new_tokens - 1:
+            return False
+        if sample_param.invalid_token_ids:
+            return False
+    return True
+
+
 def sample(logits: torch.Tensor, reqs: List[InferReq], eos_id: List[int] = [2]):
+    if is_vocab_parallel_greedy_enabled():
+        if not _can_use_unmodified_greedy_logits(reqs):
+            raise RuntimeError("LIGHTLLM_VOCAB_PARALLEL_GREEDY only supports unmodified greedy requests")
+        return unpack_vocab_parallel_greedy(logits)
+
     (
         b_req_idx,
         b_temperatures,

--- a/unit_tests/common/basemodel/triton_kernel/test_vocab_parallel_greedy.py
+++ b/unit_tests/common/basemodel/triton_kernel/test_vocab_parallel_greedy.py
@@ -1,0 +1,60 @@
+import importlib
+
+import pytest
+import torch
+
+from lightllm.common.basemodel.triton_kernel.post_process.greedy_sample import (
+    greedy_sample_local_stats,
+)
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for Triton kernels")
+
+
+@pytest.mark.parametrize("token_num", [1, 7, 64])
+def test_vocab_parallel_greedy_matches_full_logits(monkeypatch, token_num):
+    module = importlib.import_module("lightllm.common.basemodel.triton_kernel.post_process.vocab_parallel_greedy")
+    tp_world_size = 4
+    local_vocab_size = 8192
+    vocab_size = tp_world_size * local_vocab_size
+    generator = torch.Generator(device="cuda").manual_seed(20260826 + token_num)
+    local_logits_by_rank = [
+        torch.randn(
+            (local_vocab_size, token_num),
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        for _ in range(tp_world_size)
+    ]
+
+    # Exercise deterministic tie-breaking both between local reduction blocks
+    # and across tensor-parallel ranks. The smallest global token id must win.
+    local_logits_by_rank[0][4097, 0] = 20.0
+    local_logits_by_rank[0][3, 0] = 20.0
+    local_logits_by_rank[3][2, 0] = 20.0
+
+    local_stats_by_rank = [
+        greedy_sample_local_stats(local_logits.transpose(0, 1).contiguous()) for local_logits in local_logits_by_rank
+    ]
+
+    def fake_all_gather(output_tensors, _input_tensor, **_kwargs):
+        for output, local_stats in zip(output_tensors, local_stats_by_rank):
+            output.copy_(local_stats)
+
+    monkeypatch.setattr(module, "all_gather", fake_all_gather)
+    packed = module.vocab_parallel_greedy(
+        local_logits_by_rank[0],
+        vocab_size=vocab_size,
+        tp_world_size=tp_world_size,
+        group=None,
+        alloc_func=torch.empty,
+    )
+    actual_ids, actual_logprobs = module.unpack_vocab_parallel_greedy(packed)
+
+    full_logits = torch.cat(local_logits_by_rank, dim=0).transpose(0, 1).float()
+    expected_ids = full_logits.argmax(dim=1)
+    expected_logprobs = torch.log_softmax(full_logits, dim=1).gather(1, expected_ids[:, None]).squeeze(1)
+
+    torch.testing.assert_close(actual_ids, expected_ids, rtol=0, atol=0)
+    torch.testing.assert_close(actual_logprobs, expected_logprobs, rtol=2e-4, atol=2e-4)

--- a/unit_tests/server/router/model_infer/mode_backend/test_vocab_parallel_greedy_sampling.py
+++ b/unit_tests/server/router/model_infer/mode_backend/test_vocab_parallel_greedy_sampling.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import pytest
+
+from lightllm.server.router.model_infer.mode_backend.generic_post_process import (
+    _can_use_unmodified_greedy_logits,
+)
+
+
+def make_req(**overrides):
+    values = {
+        "top_k": 1,
+        "temperature": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "repetition_penalty": 1.0,
+        "min_new_tokens": 1,
+        "decay_factor": 1.0,
+        "invalid_token_ids": [],
+        "output_len": 0,
+    }
+    values.update(overrides)
+    shm_param = SimpleNamespace(
+        top_k=values["top_k"],
+        temperature=values["temperature"],
+        presence_penalty=values["presence_penalty"],
+        frequency_penalty=values["frequency_penalty"],
+        repetition_penalty=values["repetition_penalty"],
+        min_new_tokens=values["min_new_tokens"],
+        exponential_decay_length_penalty=SimpleNamespace(to_tuple=lambda: (1, values["decay_factor"])),
+    )
+    input_len = 10
+    return SimpleNamespace(
+        sampling_param=SimpleNamespace(
+            shm_param=shm_param,
+            invalid_token_ids=values["invalid_token_ids"],
+        ),
+        shm_req=SimpleNamespace(input_len=input_len),
+        get_cur_total_len=lambda: input_len + values["output_len"],
+    )
+
+
+def test_accepts_unmodified_greedy_requests():
+    assert _can_use_unmodified_greedy_logits([make_req(), make_req(output_len=5)])
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"top_k": 2},
+        {"temperature": 0.5},
+        {"presence_penalty": 0.1},
+        {"frequency_penalty": 0.1},
+        {"repetition_penalty": 1.1},
+        {"decay_factor": 1.1},
+        {"invalid_token_ids": [7]},
+        {"min_new_tokens": 2},
+    ],
+)
+def test_rejects_logits_modifiers(override):
+    assert not _can_use_unmodified_greedy_logits([make_req(**override)])


### PR DESCRIPTION
## Summary

- add an opt-in vocab-parallel greedy path enabled by `LIGHTLLM_VOCAB_PARALLEL_GREEDY=1`
- reduce TP communication from full-vocabulary logits to three FP32 values per token and rank: local max, logsumexp, and argmax
- preserve the full-logits path for prompt logprobs and integrate the packed token/logprob result with normal and MTP post-processing
- fail explicitly for sampling modifiers and constrained logits that require mutable full-vocabulary logits

## Performance

Qwen3.5-27B, 4x H100 80GB, TP=4, MTP=3, FP8, input/output=256/1024, concurrency=64, 128 requests. Both variants used the same server flags, including disabled FlashInfer allreduce, for a controlled comparison.

| Variant | Run 1 | Run 2 | Median |
| --- | ---: | ---: | ---: |
| Baseline | 6405.09 tok/s | 6578.85 tok/s | 6491.97 tok/s |
| Vocab-parallel greedy | 7245.27 tok/s | 7539.74 tok/s | 7392.51 tok/s |

Median throughput improves by **13.87%**. All 128 requests were valid with zero errors in every run.

## Verification

- CUDA/Triton kernel and strict-greedy gate tests: 12 passed
- affected backend and MTP regression suites: 101 passed
- TP=4 numerical equivalence check with the real 151,936-token vocabulary at token counts 1, 7, 64, and 256: exact token IDs and logprobs within 2e-4
- formatting, Python compilation, and staged diff checks passed

## Scope

This path is intentionally opt-in and supports only unmodified greedy requests: top-k 1, temperature 1, no penalties, invalid-token masks, minimum-new-token masking, or constrained logits.