### PR TITLE
fix(pd): add configurable decode capacity admission limit

### DIFF
--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -69,6 +69,11 @@ def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--disable_pd_master_decode_capacity_limit",
+        action="store_true",
+        help="Disable PD master admission control based on the total capacity of registered decode nodes.",
+    )
+    parser.add_argument(
         "--pd_trans_mode",
         type=str,
         choices=["nccl", "nixl"],

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -22,6 +22,7 @@ class StartArgs:
     pd_master_ip: str = field(default="0.0.0.0")
     pd_master_port: int = field(default=1212)
     pd_master_mode: str = field(default="elastic")
+    disable_pd_master_decode_capacity_limit: bool = field(default=False)
     pd_trans_mode: str = field(default="nccl", metadata={"choices": ["nccl", "nixl"]})
     config_server_host: str = field(default=None)
     config_server_port: int = field(default=None)

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -129,6 +129,11 @@ class HttpServerManagerForPDMaster:
         multimodal_params: MultimodalParams,
         request: Request,
     ):
+        if not self.args.disable_pd_master_decode_capacity_limit:
+            decode_capacity = sum(node.start_args["running_max_req_size"] for node in self.pd_manager.decode_nodes)
+            if self.running_request_count >= decode_capacity:
+                raise ServerBusyError()
+
         was_idle = self.running_request_count == 0
         self.running_request_count += 1
         if was_idle:


### PR DESCRIPTION
## Summary

Add a PD-master admission guard that computes the current capacity for every incoming request by summing `running_max_req_size` across all registered decode nodes. If the Master already has that many in-flight requests, it raises the existing `ServerBusyError` before multimodal preload, tokenization, or PD-stage waits.

The guard is enabled by default. To explicitly restore the previous behavior, start the PD Master with:

```bash
--disable_pd_master_decode_capacity_limit
```

## Motivation

Overload may otherwise be detected only after entering the PD flow and waiting 60s/180s, so clients can wait a long time before receiving 429. Decode nodes already register their complete startup arguments with the Master, and disconnected nodes are removed from `decode_nodes`, allowing the current node list to remain the single source of truth without a cached capacity value.

This is intentionally temporary:
- counts end-to-end Master requests rather than exact instantaneous D occupancy
- uses the existing static per-D request-count limits; it is not token/KV-aware admission control
- changes no streaming APIs or timeout behavior
- capacity is local to each Master; a global cap across multiple Masters remains the gateway responsibility

## Checks

- pre-commit (Black and flake8)
- `git diff --check`