### PR TITLE
feat: prioritize short chunked prefill requests

### DIFF
--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -339,6 +339,13 @@ def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     parser.add_argument("--chunked_prefill_size", type=int, default=None, help="chunked prefill size")
     parser.add_argument("--disable_chunked_prefill", action="store_true", help="whether to disable chunked prefill")
+    parser.add_argument(
+        "--short_prefill_token_threshold",
+        type=int,
+        default=None,
+        help="""Enable long/short prefill scheduling and set the maximum remaining tokens of a short request.
+        The remaining tokens are calculated after prefix-cache matching. Disabled by default.""",
+    )
     parser.add_argument("--diverse_mode", action="store_true", help="diversity generation mode")
     parser.add_argument("--token_healing_mode", action="store_true", help="code model infer mode")
 

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -98,6 +98,7 @@ class StartArgs:
     disable_dynamic_prompt_cache: bool = field(default=False)
     chunked_prefill_size: int = field(default=None)
     disable_chunked_prefill: bool = field(default=False)
+    short_prefill_token_threshold: Optional[int] = field(default=None)
     diverse_mode: bool = field(default=False)
     token_healing_mode: bool = field(default=False)
     output_constraint_mode: str = field(default="none", metadata={"choices": ["outlines", "xgrammar", "none"]})

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -610,38 +610,27 @@ class ModeBackend:
 
     def _reorder_long_prefill_reqs(self, ready_reqs: List[InferReq]) -> List[InferReq]:
         """
-        保持第一个可运行长请求之前的原始顺序，将后续长请求移到队尾。
-
-        这样排在后面的短请求可以轻量插队；如果本轮仍有 token 额度，队尾的长请求也可以运行。
-        paused、aborted、finished 和 slave 请求仍交给主循环处理，并且不占用首个长请求位置。
+        保留第一个长请求的调度位置，其余请求优先调度剩余 prefill token 更少的请求。
         """
         short_token_threshold = self.args.short_prefill_token_threshold
         if short_token_threshold is None:
             return ready_reqs
 
-        reordered_reqs = []
-        deferred_long_reqs = []
-        has_kept_long_req = False
-        for req in ready_reqs:
-            # cur_kv_len 已包含 prefix match 和之前完成的 chunk，只需计算剩余 prompt token。
-            remaining_prefill_tokens = max(0, req.shm_req.input_len - req.cur_kv_len)
-            is_runnable_long_req = (
-                remaining_prefill_tokens > short_token_threshold
-                and not req.filter_mark
-                and not req.wait_pause
-                and not req.paused
-                and not req.infer_aborted
-                and not req.finish_status.is_finished()
-                and not req.is_slave_req()
-            )
-            if is_runnable_long_req:
-                if has_kept_long_req:
-                    deferred_long_reqs.append(req)
-                    continue
-                has_kept_long_req = True
-            reordered_reqs.append(req)
+        def remaining_prefill_tokens(req: InferReq) -> int:
+            # cur_kv_len 已包含 prefix match 和之前完成的 chunk。
+            return max(0, req.shm_req.input_len - req.cur_kv_len)
 
-        return reordered_reqs + deferred_long_reqs
+        first_long_req = next(
+            (req for req in ready_reqs if remaining_prefill_tokens(req) > short_token_threshold), None
+        )
+        sorted_reqs = sorted(
+            ready_reqs,
+            key=lambda req: (remaining_prefill_tokens(req), req.shm_req.group_req_id),
+        )
+        if first_long_req is not None:
+            sorted_reqs.remove(first_long_req)
+            sorted_reqs.insert(0, first_long_req)
+        return sorted_reqs
 
     # 一些可以复用的通用功能函数
     def _get_classed_reqs(

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -620,16 +620,14 @@ class ModeBackend:
             # cur_kv_len 已包含 prefix match 和之前完成的 chunk。
             return max(0, req.shm_req.input_len - req.cur_kv_len)
 
-        first_long_req = next(
-            (req for req in ready_reqs if remaining_prefill_tokens(req) > short_token_threshold), None
-        )
         sorted_reqs = sorted(
             ready_reqs,
             key=lambda req: (remaining_prefill_tokens(req), req.shm_req.group_req_id),
         )
-        if first_long_req is not None:
-            sorted_reqs.remove(first_long_req)
-            sorted_reqs.insert(0, first_long_req)
+        for index, req in enumerate(sorted_reqs):
+            if remaining_prefill_tokens(req) > short_token_threshold:
+                sorted_reqs.insert(0, sorted_reqs.pop(index))
+                break
         return sorted_reqs
 
     # 一些可以复用的通用功能函数

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -608,6 +608,41 @@ class ModeBackend:
             )
         return
 
+    def _reorder_long_prefill_reqs(self, ready_reqs: List[InferReq]) -> List[InferReq]:
+        """
+        保持第一个可运行长请求之前的原始顺序，将后续长请求移到队尾。
+
+        这样排在后面的短请求可以轻量插队；如果本轮仍有 token 额度，队尾的长请求也可以运行。
+        paused、aborted、finished 和 slave 请求仍交给主循环处理，并且不占用首个长请求位置。
+        """
+        short_token_threshold = self.args.short_prefill_token_threshold
+        if short_token_threshold is None:
+            return ready_reqs
+
+        reordered_reqs = []
+        deferred_long_reqs = []
+        has_kept_long_req = False
+        for req in ready_reqs:
+            # cur_kv_len 已包含 prefix match 和之前完成的 chunk，只需计算剩余 prompt token。
+            remaining_prefill_tokens = max(0, req.shm_req.input_len - req.cur_kv_len)
+            is_runnable_long_req = (
+                remaining_prefill_tokens > short_token_threshold
+                and not req.filter_mark
+                and not req.wait_pause
+                and not req.paused
+                and not req.infer_aborted
+                and not req.finish_status.is_finished()
+                and not req.is_slave_req()
+            )
+            if is_runnable_long_req:
+                if has_kept_long_req:
+                    deferred_long_reqs.append(req)
+                    continue
+                has_kept_long_req = True
+            reordered_reqs.append(req)
+
+        return reordered_reqs + deferred_long_reqs
+
     # 一些可以复用的通用功能函数
     def _get_classed_reqs(
         self,
@@ -648,6 +683,7 @@ class ModeBackend:
 
         ready_reqs = self._filter_not_ready_reqs(req_ids)
         support_overlap = self.support_overlap
+        ready_reqs = self._reorder_long_prefill_reqs(ready_reqs)
 
         wait_pause_reqs = []
         paused_reqs = []

--- a/lightllm/server/router/req_queue/chunked_prefill/beam_impl.py
+++ b/lightllm/server/router/req_queue/chunked_prefill/beam_impl.py
@@ -49,8 +49,11 @@ class ChunkedBeamContinuesBatchQueue(BaseQueue):
 
         ok_req_num = len(self.cache_len_list) <= self.running_max_req_size
 
-        # prefill ok
-        ok_prefill = new_batch_first_router_need_tokens <= self.batch_max_tokens
+        # 长短请求模式由 Infer 控制单轮 prefill token 上限。
+        ok_prefill = (
+            self.args.short_prefill_token_threshold is not None
+            or new_batch_first_router_need_tokens <= self.batch_max_tokens
+        )
 
         if ok_token_num and ok_req_num and ok_prefill:
             self.router.shared_token_load.set_estimated_peak_token_count(need_max_token_num, self.dp_index)

--- a/lightllm/server/router/req_queue/chunked_prefill/impl.py
+++ b/lightllm/server/router/req_queue/chunked_prefill/impl.py
@@ -38,7 +38,11 @@ class ChunkedPrefillQueue(BaseQueue):
         ok_req_num = len(self.cache_len_list) <= self.running_max_req_size
 
         new_batch_first_router_need_tokens += req.get_first_router_need_tokens()
-        ok_prefill = new_batch_first_router_need_tokens <= self.batch_max_tokens
+        # 长短请求模式由 Infer 控制单轮 prefill token 上限。
+        ok_prefill = (
+            self.args.short_prefill_token_threshold is not None
+            or new_batch_first_router_need_tokens <= self.batch_max_tokens
+        )
 
         if ok_token_num and ok_req_num and ok_prefill:
             self.router.shared_token_load.set_estimated_peak_token_count(need_max_token_num, self.dp_index)


### PR DESCRIPTION
## Summary

- add an optional `--short_prefill_token_threshold` scheduling knob
- classify requests by remaining prompt tokens after prefix matching and completed chunks
- preserve FIFO through the first runnable long prefill request, then defer later long requests behind short requests
- let Infer own the per-step prefill budget when enabled while Router retains KV-capacity and request-count admission checks
- keep the behavior local to each DP replica through the existing per-DP request queues and Infer contexts

## Validation

- `python -m compileall` on all changed Python files
- `git diff --check`
- targeted FIFO/long-request reordering checks

The repository pre-commit hook was not run because `pre-commit` is not installed in the current environment.