### PR TITLE
perf(startup): accelerate CPU cache initialization by 3x

### DIFF
--- a/docs/CN/source/tutorial/api_server_args.rst
+++ b/docs/CN/source/tutorial/api_server_args.rst
@@ -464,6 +464,18 @@ PD 分离模式参数
 
     禁用解码阶段的 cudagraph
 
+.. option:: --startup_weight_load_mode
+
+    启动权重加载模式：``serial``（默认）或 ``overlap``。
+
+    ``overlap`` 先用可安全捕获的值填充最终 GPU 权重存储，在 CUDA Graph 捕获期间将本地 safetensors 文件
+    预读到操作系统 page cache，随后将真实权重原地写入。当前仅支持经过显式验证的 Qwen3.5 dense 与
+    Qwen3.5 DSpark 模型，以及非量化或 ``fp8w8a8-pt-sgl`` 权重。
+
+.. option:: --weight_loader_prefetch_num_threads
+
+    启动重叠模式下每个本地 rank 的 checkpoint page-cache 预取线程数，默认为 ``4``。
+
 .. option:: --graph_max_batch_size
 
     解码阶段可以被 cuda graph 捕获的最大批次大小，默认为 ``256``

--- a/docs/EN/source/tutorial/api_server_args.rst
+++ b/docs/EN/source/tutorial/api_server_args.rst
@@ -469,6 +469,19 @@ Performance Optimization Parameters
 
     Disable cudagraph in the decoding phase
 
+.. option:: --startup_weight_load_mode
+
+    Startup weight-loading mode: ``serial`` (default) or ``overlap``.
+
+    ``overlap`` fills the final GPU weight storage with capture-safe values, stages local safetensors files into the
+    OS page cache while CUDA graphs are captured, and then commits the real weights in place. It is currently limited
+    to the explicitly validated dense Qwen3.5 and Qwen3.5 DSpark models with unquantized or
+    ``fp8w8a8-pt-sgl`` weights.
+
+.. option:: --weight_loader_prefetch_num_threads
+
+    Number of checkpoint page-cache prefetch threads per local rank in startup overlap mode, default is ``4``.
+
 .. option:: --graph_max_batch_size
 
     Maximum batch size that can be captured by cuda graph in the decoding phase, default is ``256``

--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -11,6 +11,7 @@ from typing import final, List
 from tqdm import tqdm
 
 from lightllm.common.basemodel.layer_weights.hf_load_utils import load_hf_weights
+from lightllm.common.basemodel.layer_weights.startup_weight_load import StartupWeightLoadManager
 from lightllm.common.basemodel.infer_struct import InferStateInfo
 from lightllm.common.kv_cache_mem_manager import MemoryManager
 from lightllm.common.kv_cache_mem_manager.mem_utils import select_mem_manager_class
@@ -24,7 +25,7 @@ from lightllm.common.basemodel.prefill_cuda_graph import PrefillCudaGraph
 from lightllm.common.quantization import Quantcfg
 from lightllm.common.basemodel.triton_kernel.gather_token_id import gather_token, gather_token_prefill_decode_mixed
 from lightllm.utils.log_utils import init_logger
-from lightllm.utils.dist_utils import get_dp_world_size
+from lightllm.utils.dist_utils import get_current_rank_in_node, get_dp_world_size, get_node_world_size
 from lightllm.utils.profile_max_tokens import profile_mtp_weight_memory
 from lightllm.utils.envs_utils import (
     get_env_start_args,
@@ -58,6 +59,7 @@ torch.backends.cudnn.enabled = True
 
 class TpPartBaseModel:
     is_mtp_draft_model = False
+    supports_startup_weight_load_overlap = False
 
     # weight class
     pre_and_post_weight_class = None
@@ -128,26 +130,35 @@ class TpPartBaseModel:
         self._init_infer_layer()
         self._init_some_value()
         self._init_custom()
-        self.load_weights(self.weight_dict)
-        for event in self.wait_events:
-            event.wait()
+        startup_weight_manager = self._prepare_startup_weight_load_overlap()
+        if startup_weight_manager is None:
+            self.load_weights(self.weight_dict)
 
-        self._init_att_backend()
-        self._init_att_backend1()
+        try:
+            for event in self.wait_events:
+                event.wait()
 
-        logger.info(f"use prefill att backend: {self.prefill_att_backend.__class__.__name__}")
-        logger.info(f"use decode att backend: {self.decode_att_backend.__class__.__name__}")
-        if self.prefill_att_backend1 is not None:
-            logger.info(f"use prefill att backend1: {self.prefill_att_backend1.__class__.__name__}")
-            logger.info(f"use decode att backend1: {self.decode_att_backend1.__class__.__name__}")
+            self._init_att_backend()
+            self._init_att_backend1()
 
-        self._init_hidden_collector()
-        self._autotune_warmup()
-        self._full_att_decode_autotune()
-        self._init_padded_req()
-        self._init_cudagraph()
-        self._init_prefill_cuda_graph()
-        self._check_max_len_infer()
+            logger.info(f"use prefill att backend: {self.prefill_att_backend.__class__.__name__}")
+            logger.info(f"use decode att backend: {self.decode_att_backend.__class__.__name__}")
+            if self.prefill_att_backend1 is not None:
+                logger.info(f"use prefill att backend1: {self.prefill_att_backend1.__class__.__name__}")
+                logger.info(f"use decode att backend1: {self.decode_att_backend1.__class__.__name__}")
+
+            self._init_hidden_collector()
+            self._autotune_warmup()
+            self._full_att_decode_autotune()
+            self._init_padded_req()
+            self._init_cudagraph()
+            self._init_prefill_cuda_graph()
+            self._check_max_len_infer()
+            if startup_weight_manager is not None:
+                startup_weight_manager.commit(lambda: self.load_weights(self.weight_dict))
+        finally:
+            if startup_weight_manager is not None:
+                startup_weight_manager.stop_prefetch()
         torch.cuda.empty_cache()
         set_model_init_status(True)
         return
@@ -202,6 +213,47 @@ class TpPartBaseModel:
         self.pre_post_weight.verify_load()
         [weight.verify_load() for weight in self.trans_layers_weight]
         return
+
+    def _prepare_startup_weight_load_overlap(self):
+        mode = getattr(self.args, "startup_weight_load_mode", "serial")
+        if mode == "serial":
+            return None
+        if mode != "overlap":
+            raise ValueError(f"Unknown startup_weight_load_mode: {mode}")
+        if not self.__class__.__dict__.get("supports_startup_weight_load_overlap", False):
+            raise ValueError(
+                f"startup weight overlap is not supported for {self.__class__.__name__}; "
+                "only explicitly validated model classes may opt in"
+            )
+        if self.weight_dict is not None:
+            raise ValueError("startup weight overlap does not support in-memory weight_dict loading")
+        if self.disable_cudagraph and not self.args.enable_prefill_cudagraph:
+            raise ValueError("startup weight overlap requires decode or prefill CUDA Graph capture")
+        if self.args.enable_torch_memory_saver or self.args.enable_weight_cpu_backup:
+            raise ValueError("startup weight overlap does not support weight memory saver or CPU backup")
+        if self.data_type not in (torch.float16, torch.bfloat16):
+            raise ValueError("startup weight overlap supports FP16 and BF16 model dtypes only")
+
+        quant_types = {self.quant_cfg.quant_type}
+        for layer_config in self.quant_cfg.quant_cfg.values():
+            quant_types.update(layer_config.values())
+        unsupported_quant_types = quant_types - {"none", "fp8w8a8-pt-sgl"}
+        if unsupported_quant_types:
+            raise ValueError(
+                "startup weight overlap supports unquantized and fp8w8a8-pt-sgl weights only; "
+                f"got {sorted(unsupported_quant_types)}"
+            )
+
+        manager = StartupWeightLoadManager(
+            pre_post_layer=self.pre_post_weight,
+            transformer_layer_list=self.trans_layers_weight,
+            weight_dir=self.weight_dir_,
+            num_threads=self.args.weight_loader_prefetch_num_threads,
+            rank_in_node=get_current_rank_in_node(),
+            node_world_size=get_node_world_size(),
+        )
+        manager.prepare()
+        return manager
 
     def _init_mem_manager(self):
         assert self.config["num_attention_heads"] % self.tp_world_size_ == 0
@@ -294,11 +346,10 @@ class TpPartBaseModel:
             )
         )
         if self.graph is not None:
-            initial_batch_sizes = self.graph.cuda_graph_batch_sizes[:1]
             if get_env_start_args().enable_decode_microbatch_overlap:
-                self.graph.warmup_overlap(self, batch_sizes=initial_batch_sizes)
+                self.graph.warmup_overlap(self)
             else:
-                self.graph.warmup(self, batch_sizes=initial_batch_sizes)
+                self.graph.warmup(self)
 
     def _init_prefill_cuda_graph(self):
         self.prefill_graph = (

--- a/lightllm/common/basemodel/basemodel.py
+++ b/lightllm/common/basemodel/basemodel.py
@@ -82,6 +82,7 @@ class TpPartBaseModel:
         self.finetune_config = kvargs.get("finetune_config", None)
         self.max_req_num = kvargs.get("max_req_num", 1000)
         self.max_seq_length = kvargs.get("max_seq_length", 1024 * 5)
+        self.wait_events = kvargs.get("wait_events", [])
         self.return_all_prompt_logics = kvargs.get("return_all_prompt_logics", False)
         self.data_type = get_llm_data_type()
         self.graph_max_batch_size = kvargs.get("graph_max_batch_size", 16)
@@ -128,6 +129,8 @@ class TpPartBaseModel:
         self._init_some_value()
         self._init_custom()
         self.load_weights(self.weight_dict)
+        for event in self.wait_events:
+            event.wait()
 
         self._init_att_backend()
         self._init_att_backend1()
@@ -291,10 +294,11 @@ class TpPartBaseModel:
             )
         )
         if self.graph is not None:
+            initial_batch_sizes = self.graph.cuda_graph_batch_sizes[:1]
             if get_env_start_args().enable_decode_microbatch_overlap:
-                self.graph.warmup_overlap(self)
+                self.graph.warmup_overlap(self, batch_sizes=initial_batch_sizes)
             else:
-                self.graph.warmup(self)
+                self.graph.warmup(self, batch_sizes=initial_batch_sizes)
 
     def _init_prefill_cuda_graph(self):
         self.prefill_graph = (

--- a/lightllm/common/basemodel/cuda_graph.py
+++ b/lightllm/common/basemodel/cuda_graph.py
@@ -243,14 +243,15 @@ class CudaGraph:
             return self._replay(infer_state)
 
     @torch.no_grad()
-    def warmup(self, model):
+    def warmup(self, model, batch_sizes=None):
         logger.info("Begin capture cudagraph, use the --disable_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 
         model: TpPartBaseModel = model
         # decode cuda graph init
-        for batch_size in self.cuda_graph_batch_sizes[::-1]:
+        batch_sizes = self.cuda_graph_batch_sizes if batch_sizes is None else batch_sizes
+        for batch_size in batch_sizes[::-1]:
             seq_len = 2
             total_token_num = batch_size * seq_len
             max_len_in_batch = self.graph_max_len_in_batch
@@ -296,19 +297,17 @@ class CudaGraph:
                     del locals()[var_name]
             torch.cuda.empty_cache()
 
-        logger.info(
-            f"Capture cudagraph success, batch_size <={self.max_batch_size} "
-            f"and max_len_in_batch <= {self.graph_max_len_in_batch} will infer with cudagraph."
-        )
+        logger.info(f"Captured initial CUDA graphs for batch sizes {batch_sizes}; remaining sizes capture on demand.")
 
     @torch.no_grad()
-    def warmup_overlap(self, model):
+    def warmup_overlap(self, model, batch_sizes=None):
         logger.info("Begin capture overlap cudagraph, use the --disable_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 
         model: TpPartBaseModel = model
-        for batch_size in self.cuda_graph_batch_sizes[::-1]:
+        batch_sizes = self.cuda_graph_batch_sizes if batch_sizes is None else batch_sizes
+        for batch_size in batch_sizes[::-1]:
             decode_batches = []
             for micro_batch_index in [0, 1]:
                 # dummy decoding, capture the cudagraph
@@ -364,6 +363,5 @@ class CudaGraph:
             torch.cuda.empty_cache()
 
         logger.info(
-            f"Capture overlap cudagraph success, batch_size <={self.max_batch_size} "
-            f"and max_len_in_batch <= {self.graph_max_len_in_batch} will infer with cudagraph."
+            f"Captured initial overlap CUDA graphs for batch sizes {batch_sizes}; remaining sizes capture on demand."
         )

--- a/lightllm/common/basemodel/cuda_graph.py
+++ b/lightllm/common/basemodel/cuda_graph.py
@@ -243,15 +243,14 @@ class CudaGraph:
             return self._replay(infer_state)
 
     @torch.no_grad()
-    def warmup(self, model, batch_sizes=None):
+    def warmup(self, model):
         logger.info("Begin capture cudagraph, use the --disable_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 
         model: TpPartBaseModel = model
         # decode cuda graph init
-        batch_sizes = self.cuda_graph_batch_sizes if batch_sizes is None else batch_sizes
-        for batch_size in batch_sizes[::-1]:
+        for batch_size in self.cuda_graph_batch_sizes[::-1]:
             seq_len = 2
             total_token_num = batch_size * seq_len
             max_len_in_batch = self.graph_max_len_in_batch
@@ -297,17 +296,19 @@ class CudaGraph:
                     del locals()[var_name]
             torch.cuda.empty_cache()
 
-        logger.info(f"Captured initial CUDA graphs for batch sizes {batch_sizes}; remaining sizes capture on demand.")
+        logger.info(
+            f"Capture cudagraph success, batch_size <={self.max_batch_size} "
+            f"and max_len_in_batch <= {self.graph_max_len_in_batch} will infer with cudagraph."
+        )
 
     @torch.no_grad()
-    def warmup_overlap(self, model, batch_sizes=None):
+    def warmup_overlap(self, model):
         logger.info("Begin capture overlap cudagraph, use the --disable_cudagraph to disable it.")
         # for typing easy
         from .basemodel import TpPartBaseModel
 
         model: TpPartBaseModel = model
-        batch_sizes = self.cuda_graph_batch_sizes if batch_sizes is None else batch_sizes
-        for batch_size in batch_sizes[::-1]:
+        for batch_size in self.cuda_graph_batch_sizes[::-1]:
             decode_batches = []
             for micro_batch_index in [0, 1]:
                 # dummy decoding, capture the cudagraph
@@ -363,5 +364,6 @@ class CudaGraph:
             torch.cuda.empty_cache()
 
         logger.info(
-            f"Captured initial overlap CUDA graphs for batch sizes {batch_sizes}; remaining sizes capture on demand."
+            f"Capture overlap cudagraph success, batch_size <={self.max_batch_size} "
+            f"and max_len_in_batch <= {self.graph_max_len_in_batch} will infer with cudagraph."
         )

--- a/lightllm/common/basemodel/layer_weights/startup_weight_load.py
+++ b/lightllm/common/basemodel/layer_weights/startup_weight_load.py
@@ -1,0 +1,311 @@
+import concurrent.futures
+import dataclasses
+import os
+import threading
+import time
+from typing import Callable, List, Optional, Tuple
+
+import torch
+
+from lightllm.common.basemodel.layer_weights.meta_weights.base_weight import BaseWeight
+from lightllm.common.quantization.quantize_method import WeightPack
+from lightllm.utils.log_utils import init_logger
+
+
+logger = init_logger(__name__)
+
+CAPTURE_SAFE_WEIGHT_SENTINEL = 1e-3
+_PREFETCH_BLOCK_SIZE = 16 * 1024 * 1024
+_PREFETCH_STOP_TIMEOUT_SECONDS = 30
+
+
+def _iter_weight_tensors(pre_post_layer, transformer_layer_list):
+    """Yield every tensor owned by LightLLM's graph-visible weight objects."""
+    seen_objects = set()
+    seen_tensors = set()
+
+    def visit(value, name):
+        if isinstance(value, torch.Tensor):
+            tensor_id = id(value)
+            if tensor_id not in seen_tensors:
+                seen_tensors.add(tensor_id)
+                yield name, value
+            return
+
+        if isinstance(value, (BaseWeight, WeightPack)):
+            object_id = id(value)
+            if object_id in seen_objects:
+                return
+            seen_objects.add(object_id)
+            for attr_name, attr in sorted(vars(value).items()):
+                yield from visit(attr, f"{name}.{attr_name}")
+            return
+
+        if isinstance(value, (list, tuple)):
+            for index, item in enumerate(value):
+                yield from visit(item, f"{name}[{index}]")
+            return
+
+        if isinstance(value, dict):
+            for key in sorted(value, key=str):
+                yield from visit(value[key], f"{name}[{key!r}]")
+
+    roots = []
+    if pre_post_layer is not None:
+        roots.append(("pre_post", pre_post_layer))
+    if transformer_layer_list is not None:
+        roots.extend((f"layers[{index}]", layer) for index, layer in enumerate(transformer_layer_list))
+
+    for root_name, root in roots:
+        for attr_name, attr in sorted(vars(root).items()):
+            if isinstance(attr, (BaseWeight, WeightPack, torch.Tensor, list, tuple, dict)):
+                yield from visit(attr, f"{root_name}.{attr_name}")
+
+
+@dataclasses.dataclass(frozen=True)
+class TensorStorageMetadata:
+    name: str
+    tensor: torch.Tensor = dataclasses.field(repr=False, compare=False)
+    data_ptr: int
+    shape: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+    storage_offset: int
+
+    @classmethod
+    def from_tensor(cls, name: str, tensor: torch.Tensor):
+        return cls(
+            name=name,
+            tensor=tensor,
+            data_ptr=tensor.data_ptr(),
+            shape=tuple(tensor.shape),
+            stride=tuple(tensor.stride()),
+            dtype=tensor.dtype,
+            device=tensor.device,
+            storage_offset=tensor.storage_offset(),
+        )
+
+    def matches(self, other) -> bool:
+        return self.tensor is other.tensor and (
+            self.data_ptr,
+            self.shape,
+            self.stride,
+            self.dtype,
+            self.device,
+            self.storage_offset,
+        ) == (
+            other.data_ptr,
+            other.shape,
+            other.stride,
+            other.dtype,
+            other.device,
+            other.storage_offset,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class WeightStorageManifest:
+    tensors: Tuple[TensorStorageMetadata, ...]
+    device_type: Optional[str]
+
+    @classmethod
+    def capture(cls, pre_post_layer, transformer_layer_list, device_type: Optional[str] = "cuda"):
+        entries = []
+        for name, tensor in _iter_weight_tensors(pre_post_layer, transformer_layer_list):
+            if device_type is None or tensor.device.type == device_type:
+                entries.append(TensorStorageMetadata.from_tensor(name, tensor))
+        return cls(tensors=tuple(entries), device_type=device_type)
+
+    def changed_names(self, pre_post_layer, transformer_layer_list) -> Tuple[str, ...]:
+        after = WeightStorageManifest.capture(
+            pre_post_layer,
+            transformer_layer_list,
+            device_type=self.device_type,
+        )
+        before_by_id = {id(metadata.tensor): metadata for metadata in self.tensors}
+        after_by_id = {id(metadata.tensor): metadata for metadata in after.tensors}
+        changed = set()
+        for tensor_id in sorted(before_by_id.keys() | after_by_id.keys()):
+            before = before_by_id.get(tensor_id)
+            current = after_by_id.get(tensor_id)
+            if before is None:
+                changed.add(current.name)
+            elif current is None or not before.matches(current):
+                changed.add(before.name)
+        return tuple(sorted(changed))
+
+    def unchanged_floating_names(self, value: float) -> Tuple[str, ...]:
+        names = []
+        checks = []
+        for metadata in self.tensors:
+            tensor = metadata.tensor
+            if torch.is_floating_point(tensor):
+                names.append(metadata.name)
+                checks.append(torch.all(tensor == value))
+        if not checks:
+            return ()
+        unchanged = torch.stack(checks).cpu().tolist()
+        return tuple(name for name, is_unchanged in zip(names, unchanged) if is_unchanged)
+
+
+@torch.no_grad()
+def initialize_capture_safe_weights(
+    pre_post_layer,
+    transformer_layer_list,
+    value: float = CAPTURE_SAFE_WEIGHT_SENTINEL,
+    device_type: Optional[str] = "cuda",
+) -> None:
+    for _, tensor in _iter_weight_tensors(pre_post_layer, transformer_layer_list):
+        if (device_type is None or tensor.device.type == device_type) and torch.is_floating_point(tensor):
+            tensor.fill_(value)
+
+
+class CheckpointPrefetchHandle:
+    def __init__(self, paths: List[str], num_threads: int):
+        self._paths = paths
+        self._num_threads = num_threads
+        self._cancel_event = threading.Event()
+        self._errors = []
+        self._thread = threading.Thread(target=self._run, name="checkpoint-page-cache-prefetch", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _prefetch_file(self, path: str) -> None:
+        with open(path, "rb") as checkpoint_file:
+            while not self._cancel_event.is_set():
+                if not checkpoint_file.read(_PREFETCH_BLOCK_SIZE):
+                    break
+
+    def _run(self) -> None:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self._num_threads) as executor:
+            pending = {executor.submit(self._prefetch_file, path): path for path in self._paths}
+            for future in concurrent.futures.as_completed(pending):
+                path = pending[future]
+                try:
+                    future.result()
+                except Exception as error:
+                    self._errors.append((path, error))
+
+    @property
+    def done(self) -> bool:
+        return not self._thread.is_alive()
+
+    @property
+    def errors(self):
+        return tuple(self._errors)
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        self._thread.join(timeout)
+        if self._thread.is_alive():
+            raise TimeoutError("Timed out waiting for checkpoint page-cache prefetch")
+
+    def stop(self, timeout: float = _PREFETCH_STOP_TIMEOUT_SECONDS) -> None:
+        self._cancel_event.set()
+        self.wait(timeout)
+
+
+def start_checkpoint_prefetch(
+    weight_dir: str,
+    num_threads: int,
+    rank_in_node: int,
+    node_world_size: int,
+) -> CheckpointPrefetchHandle:
+    if num_threads < 1:
+        raise ValueError("weight_loader_prefetch_num_threads must be at least 1")
+    if not os.path.isdir(weight_dir):
+        raise ValueError("startup weight overlap supports local checkpoint directories only")
+
+    paths = sorted(os.path.join(weight_dir, name) for name in os.listdir(weight_dir) if name.endswith(".safetensors"))
+    if not paths:
+        raise ValueError("startup weight overlap requires a safetensors checkpoint")
+    local_paths = paths[rank_in_node::node_world_size]
+    logger.info(
+        "Start checkpoint page-cache prefetch for %d/%d shards with %d threads on local rank %d.",
+        len(local_paths),
+        len(paths),
+        num_threads,
+        rank_in_node,
+    )
+    handle = CheckpointPrefetchHandle(local_paths, num_threads)
+    handle.start()
+    return handle
+
+
+class StartupWeightLoadManager:
+    """Overlap checkpoint page-cache staging with capture, then commit in place."""
+
+    def __init__(
+        self,
+        pre_post_layer,
+        transformer_layer_list,
+        weight_dir: str,
+        num_threads: int,
+        rank_in_node: int,
+        node_world_size: int,
+    ):
+        self.pre_post_layer = pre_post_layer
+        self.transformer_layer_list = transformer_layer_list
+        self.weight_dir = weight_dir
+        self.num_threads = num_threads
+        self.rank_in_node = rank_in_node
+        self.node_world_size = node_world_size
+        self.prefetch_handle = None
+        self.started_at = None
+
+    def prepare(self) -> None:
+        initialize_capture_safe_weights(self.pre_post_layer, self.transformer_layer_list)
+        torch.cuda.synchronize()
+        self.started_at = time.perf_counter()
+        self.prefetch_handle = start_checkpoint_prefetch(
+            weight_dir=self.weight_dir,
+            num_threads=self.num_threads,
+            rank_in_node=self.rank_in_node,
+            node_world_size=self.node_world_size,
+        )
+
+    def commit(self, load_weights: Callable[[], None]) -> None:
+        if self.prefetch_handle is None:
+            raise RuntimeError("startup weight overlap was not prepared")
+        manifest = WeightStorageManifest.capture(self.pre_post_layer, self.transformer_layer_list)
+        commit_started_at = time.perf_counter()
+        try:
+            load_weights()
+            torch.cuda.synchronize()
+        finally:
+            self.stop_prefetch()
+
+        changed_names = manifest.changed_names(self.pre_post_layer, self.transformer_layer_list)
+        if changed_names:
+            raise RuntimeError(
+                "Startup weight commit changed graph-visible tensor storage: " + ", ".join(changed_names[:8])
+            )
+        unchanged_names = manifest.unchanged_floating_names(CAPTURE_SAFE_WEIGHT_SENTINEL)
+        if unchanged_names:
+            raise RuntimeError(
+                "Startup weight commit did not replace capture-safe values: " + ", ".join(unchanged_names[:8])
+            )
+        logger.info(
+            "Committed real weights after CUDA Graph capture in %.2fs (overlap window %.2fs).",
+            time.perf_counter() - commit_started_at,
+            commit_started_at - self.started_at,
+        )
+
+    def stop_prefetch(self) -> None:
+        handle = self.prefetch_handle
+        if handle is None:
+            return
+        self.prefetch_handle = None
+        try:
+            handle.stop()
+        except TimeoutError as error:
+            logger.warning("%s; the daemon prefetch thread will exit asynchronously.", error)
+        if handle.errors:
+            path, error = handle.errors[0]
+            logger.warning(
+                "Checkpoint prefetch had %d failure(s), first at %s: %s. Normal weight loading still ran.",
+                len(handle.errors),
+                path,
+                error,
+            )

--- a/lightllm/common/cpu_cache/creator.py
+++ b/lightllm/common/cpu_cache/creator.py
@@ -2,8 +2,14 @@ import ctypes
 import torch
 import numpy as np
 from dataclasses import dataclass
-from typing import Tuple
-from lightllm.utils.kv_cache_utils import attach_shm_kv_cache_ptr, create_shm_kv_cache_ptr, register_shm_ptr_to_pin
+from typing import Optional, Tuple
+from lightllm.utils.kv_cache_utils import (
+    AsyncRegistrationHandle,
+    attach_shm_kv_cache_ptr,
+    create_shm_kv_cache_ptr,
+    register_shm_ptr_to_pin,
+    register_shm_ptr_to_pin_async,
+)
 
 
 @dataclass(frozen=True)
@@ -18,14 +24,23 @@ class CpuCacheCreator:
     def __init__(self, tensor_spec: CpuCacheTensorSpec):
         self.tensor_spec = tensor_spec
 
-    def create_or_attach(self, init_shm_data: bool, pin: bool) -> torch.Tensor:
+    def create_or_attach(
+        self,
+        init_shm_data: bool,
+        pin: bool,
+        pin_ranges: Optional[Tuple[Tuple[int, int], ...]] = None,
+    ) -> torch.Tensor:
         if init_shm_data:
             shm_ptr = create_shm_kv_cache_ptr(key=self.tensor_spec.shm_key, size=self.tensor_spec.size_bytes)
         else:
             shm_ptr = attach_shm_kv_cache_ptr(key=self.tensor_spec.shm_key, size=self.tensor_spec.size_bytes)
 
         if pin:
-            device_ptr = register_shm_ptr_to_pin(shm_ptr=shm_ptr, size=self.tensor_spec.size_bytes)
+            device_ptr = register_shm_ptr_to_pin(
+                shm_ptr=shm_ptr,
+                size=self.tensor_spec.size_bytes,
+                ranges=pin_ranges,
+            )
             cpu_cache_tensor = self._build_tensor_view(shm_ptr=device_ptr)
             assert device_ptr == cpu_cache_tensor.data_ptr()
         else:
@@ -33,6 +48,21 @@ class CpuCacheCreator:
             assert shm_ptr == cpu_cache_tensor.data_ptr()
 
         return cpu_cache_tensor
+
+    def create_or_attach_async(
+        self,
+        pin_ranges: Optional[Tuple[Tuple[int, int], ...]] = None,
+    ) -> Tuple[torch.Tensor, AsyncRegistrationHandle]:
+        shm_ptr = attach_shm_kv_cache_ptr(key=self.tensor_spec.shm_key, size=self.tensor_spec.size_bytes)
+        handle = register_shm_ptr_to_pin_async(
+            shm_ptr=shm_ptr,
+            size=self.tensor_spec.size_bytes,
+            ranges=pin_ranges,
+        )
+        device_ptr = handle.wait_for_device_ptr()
+        cpu_cache_tensor = self._build_tensor_view(shm_ptr=device_ptr)
+        assert device_ptr == cpu_cache_tensor.data_ptr()
+        return cpu_cache_tensor, handle
 
     def _build_tensor_view(self, shm_ptr: int) -> torch.Tensor:
         numpy_array = np.frombuffer(

--- a/lightllm/common/linear_att_cache_manager/config_objs.py
+++ b/lightllm/common/linear_att_cache_manager/config_objs.py
@@ -105,6 +105,45 @@ class LinearAttCacheConfig:
         c = self.get_ssm_state_bytes_per_layer() * self.linear_layer_num * self.tp_world_size
         return c
 
+    def get_cpu_cache_rank_registration_ranges(self, page_num: int, tp_rank: int):
+        """Return the byte ranges in shared CPU cache that this TP rank can access."""
+        tp_world_size = self.tp_world_size
+        assert 0 <= tp_rank < tp_world_size
+
+        if self.full_att_all_num_kv_heads % tp_world_size == 0:
+            full_att_shard_num = tp_world_size
+            full_att_shard_index = tp_rank
+        else:
+            assert tp_world_size % self.full_att_all_num_kv_heads == 0
+            ranks_per_kv_head = tp_world_size // self.full_att_all_num_kv_heads
+            full_att_shard_num = self.full_att_all_num_kv_heads
+            full_att_shard_index = tp_rank // ranks_per_kv_head
+
+        full_att_bytes = self.get_cpu_cache_full_att_bytes()
+        conv_bytes = self.get_cpu_cache_conv_bytes()
+        ssm_bytes = self.get_cpu_cache_ssm_bytes()
+        page_bytes = self.get_cpu_cache_big_page_bytes()
+        assert full_att_bytes % full_att_shard_num == 0
+        assert conv_bytes % tp_world_size == 0
+        assert ssm_bytes % tp_world_size == 0
+
+        full_att_rank_bytes = full_att_bytes // full_att_shard_num
+        conv_rank_bytes = conv_bytes // tp_world_size
+        ssm_rank_bytes = ssm_bytes // tp_world_size
+        # Triton validates the logical base pointer of each strided view before
+        # launch, even though the kernel only dereferences this rank's shard.
+        ranges = [(0, 1), (full_att_bytes, 1), (full_att_bytes + conv_bytes, 1)]
+        for page_index in range(page_num):
+            page_offset = page_index * page_bytes
+            ranges.extend(
+                (
+                    (page_offset + full_att_shard_index * full_att_rank_bytes, full_att_rank_bytes),
+                    (page_offset + full_att_bytes + tp_rank * conv_rank_bytes, conv_rank_bytes),
+                    (page_offset + full_att_bytes + conv_bytes + tp_rank * ssm_rank_bytes, ssm_rank_bytes),
+                )
+            )
+        return tuple(ranges)
+
     @staticmethod
     def load_from_args() -> "LinearAttCacheConfig":
         args = get_env_start_args()

--- a/lightllm/distributed/communication_op.py
+++ b/lightllm/distributed/communication_op.py
@@ -59,6 +59,9 @@ class CustomProcessGroup:
         self.flashinfer_reduce = None
         self.dp_world_size = get_dp_world_size()
         self.device_group = create_new_group_for_current_dp("nccl")
+        self.optional_allreduce_group = (
+            create_new_group_for_current_dp("gloo") if self.dp_world_size in [2, 4, 6, 8] else None
+        )
         if get_env_start_args().enable_dp_prefill_balance:
             self.dp_prefill_balance_group = create_dp_special_inter_group("nccl")
         else:
@@ -66,8 +69,17 @@ class CustomProcessGroup:
 
         self.autotune_group = dist.new_group([i for i in range(get_global_world_size())], backend="gloo")
 
+    def _all_ranks_agree(self, local_enabled: bool) -> bool:
+        """Enable an optional collective only when every rank can use it."""
+        assert self.optional_allreduce_group is not None
+        enabled = torch.tensor([int(local_enabled)], dtype=torch.int32)
+        dist.all_reduce(enabled, op=dist.ReduceOp.MIN, group=self.optional_allreduce_group)
+        return bool(enabled.item())
+
     def _support_custom_allreduce(self) -> bool:
-        return has_nvlink() and self.dp_world_size in [2, 4, 6, 8]
+        if self.optional_allreduce_group is None:
+            return False
+        return self._all_ranks_agree(has_nvlink())
 
     def init_symm_mem_reduce(self) -> None:
         if not self._support_custom_allreduce():
@@ -75,21 +87,34 @@ class CustomProcessGroup:
         from .symm_mem_all_reduce import SymmMemAllreduce
 
         data_type = get_torch_dtype(get_env_start_args().data_type)
-        symm = SymmMemAllreduce(self.device_group, torch.cuda.current_device(), dtype=data_type)
-        if not symm.disabled:
+        try:
+            symm = SymmMemAllreduce(self.device_group, torch.cuda.current_device(), dtype=data_type)
+        except Exception as error:
+            logger.warning("SymmMem ALLReduce initialization failed: %s", error)
+            symm = None
+        local_enabled = symm is not None and not symm.disabled
+        if self._all_ranks_agree(local_enabled):
             self.symm_mem_reduce = symm
             logger.info("Enable SymmMem ALLReduce.")
+        elif local_enabled:
+            logger.warning("Disable SymmMem ALLReduce because at least one rank could not initialize it.")
 
     def init_flashinfer_reduce(self) -> None:
         if not self._support_custom_allreduce():
             return
         from .flashinfer_all_reduce import FlashInferAllReduce
 
-        fi_cpu_group = create_new_group_for_current_dp("gloo")
-        fi = FlashInferAllReduce(fi_cpu_group, torch.cuda.current_device())
-        if not fi.disabled:
+        try:
+            fi = FlashInferAllReduce(self.optional_allreduce_group, torch.cuda.current_device())
+        except Exception as error:
+            logger.warning("FlashInfer ALLReduce initialization failed: %s", error)
+            fi = None
+        local_enabled = fi is not None and not fi.disabled
+        if self._all_ranks_agree(local_enabled):
             self.flashinfer_reduce = fi
             logger.info("Enable FlashInfer ALLReduce.")
+        elif local_enabled:
+            logger.warning("Disable FlashInfer ALLReduce because at least one rank could not initialize it.")
 
     def all_reduce(self, input_: torch.Tensor) -> None:
         # Dispatch chain: FlashInfer -> SymmMem -> NCCL.

--- a/lightllm/distributed/flashinfer_all_reduce.py
+++ b/lightllm/distributed/flashinfer_all_reduce.py
@@ -17,7 +17,7 @@ try:
     _FI_OK = hasattr(flashinfer_comm, "allreduce_fusion") and hasattr(
         flashinfer_comm, "create_allreduce_fusion_workspace"
     )
-except ImportError:
+except Exception:
     flashinfer_comm = None
     TorchDistBackend = None
     _FI_OK = False
@@ -92,6 +92,7 @@ class FlashInferAllReduce:
                 pass
             self._workspace = None
         rng_state = random.getstate()
+        init_error = None
         try:
             random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
             self._workspace = flashinfer_comm.create_allreduce_fusion_workspace(
@@ -104,12 +105,27 @@ class FlashInferAllReduce:
                 comm_backend=TorchDistBackend(group=self.group),
             )
         except Exception as e:
-            logger.warning("FlashInferAllReduce workspace init failed: %s. Disabling.", e)
-            self.disabled = True
+            init_error = e
             self._workspace = None
-            return False
         finally:
             random.setstate(rng_state)
+
+        workspace_ready = torch.tensor([int(self._workspace is not None)], dtype=torch.int32)
+        dist.all_reduce(workspace_ready, op=dist.ReduceOp.MIN, group=self.group)
+        if not workspace_ready.item():
+            if self._workspace is not None:
+                try:
+                    self._workspace.destroy()
+                except Exception:
+                    pass
+            self.disabled = True
+            self._workspace = None
+            if init_error is not None:
+                logger.warning("FlashInferAllReduce workspace init failed: %s. Disabling on every rank.", init_error)
+            else:
+                logger.warning("FlashInferAllReduce workspace init failed on another rank. Disabling on every rank.")
+            return False
+
         self._ws_hidden_dim = hidden_dim
         self._ws_dtype = dtype
         self._ws_max_token_num = max_token_num

--- a/lightllm/models/qwen3_5/model.py
+++ b/lightllm/models/qwen3_5/model.py
@@ -58,6 +58,7 @@ class Qwen3_5TpPartModel(Qwen3NextTpPartModel):
     transformer_layer_infer_class = Qwen35TransformerLayerInfer
 
     infer_state_class = Qwen35InferStateInfo
+    supports_startup_weight_load_overlap = True
 
     def _init_config(self):
         config_path = os.path.join(self.weight_dir_, "config.json")

--- a/lightllm/models/qwen3_5_dspark/model.py
+++ b/lightllm/models/qwen3_5_dspark/model.py
@@ -7,6 +7,8 @@ from lightllm.models.draft_registry import DraftModelRegistry
 class Qwen3_5DSparkModel(Qwen3DSparkModel):
     """Adapter for the current Qwen3 DSpark checkpoint with a Qwen3.5 target."""
 
+    supports_startup_weight_load_overlap = True
+
     def _init_config(self):
         super()._init_config()
         self.config.update(self.config.get("dflash_config", {}))

--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -589,6 +589,18 @@ def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     )
     parser.add_argument("--disable_cudagraph", action="store_true", help="Disable the cudagraph of the decoding stage")
     parser.add_argument(
+        "--startup_weight_load_mode",
+        choices=["serial", "overlap"],
+        default="serial",
+        help="Overlap checkpoint page-cache staging with CUDA Graph capture before committing real weights.",
+    )
+    parser.add_argument(
+        "--weight_loader_prefetch_num_threads",
+        type=int,
+        default=4,
+        help="Number of checkpoint page-cache prefetch threads per local rank in startup overlap mode.",
+    )
+    parser.add_argument(
         "--enable_prefill_cudagraph",
         action="store_true",
         help="Enable the cudagraph of the prefill stage,"

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -50,6 +50,7 @@ from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.envs_utils import get_unique_server_name
 from lightllm.utils.shm_port_args import get_shm_port_args
+from lightllm.utils.startup_status import is_server_ready
 from dataclasses import asdict, dataclass, is_dataclass
 
 from .api_errors import create_error_response, create_server_busy_response
@@ -185,7 +186,8 @@ def readiness():
             {"status": "ok" if pd_nodes_are_ready else "not ready"},
             status_code=200 if pd_nodes_are_ready else 503,
         )
-    return {"status": "ok"}
+    ready = is_server_ready()
+    return JSONResponse({"status": "ok" if ready else "not ready"}, status_code=200 if ready else 503)
 
 
 @app.get("/get_model_name")
@@ -250,6 +252,9 @@ async def healthcheck(request: Request):
             }
         )
         return JSONResponse(health_info, status_code=200 if is_healthy else 503)
+
+    if not is_server_ready():
+        return JSONResponse({"message": "Starting"}, status_code=503)
 
     from lightllm.utils.health_check import health_check
 

--- a/lightllm/server/api_start.py
+++ b/lightllm/server/api_start.py
@@ -25,6 +25,7 @@ from lightllm.utils.config_utils import (
     auto_set_response_parsers,
 )
 from lightllm.utils.dist_check_utils import auto_configure_allreduce_flags_from_args
+from lightllm.utils.startup_status import set_cpu_cache_ready, set_server_ready
 
 logger = init_logger(__name__)
 
@@ -378,33 +379,37 @@ def _launch_subprocesses(args: StartArgs):
             ],
         )
 
+    set_server_ready(False)
+    if args.enable_cpu_cache:
+        set_cpu_cache_ready(False)
+    http_server_process = _start_http_server(args)
+
+    core_start_funcs = []
+    core_start_args = []
     if args.enable_cpu_cache:
         from .multi_level_kv_cache.manager import start_multi_level_kv_cache_manager
 
-        process_manager.start_submodule_processes(
-            start_funcs=[
-                start_multi_level_kv_cache_manager,
-            ],
-            start_args=[(args,)],
+        core_start_funcs.append(start_multi_level_kv_cache_manager)
+        core_start_args.append((args,))
+    core_start_funcs.append(start_metric_manager)
+    core_start_args.append((args,))
+    router_process_index = len(core_start_funcs)
+    core_start_funcs.extend((start_router_process, start_detokenization_process))
+    core_start_args.extend(((args,), (args,)))
+    try:
+        processes = process_manager.start_submodule_processes(
+            start_funcs=core_start_funcs,
+            start_args=core_start_args,
         )
-
-    process_manager.start_submodule_processes(
-        start_funcs=[
-            start_metric_manager,
-        ],
-        start_args=[(args,)],
-    )
-
-    router_process, _ = process_manager.start_submodule_processes(
-        start_funcs=[start_router_process, start_detokenization_process],
-        start_args=[
-            (args,),
-            (args,),
-        ],
-    )
+    except BaseException:
+        http_server_process.terminate()
+        http_server_process.wait()
+        raise
+    router_process = processes[router_process_index]
     process_manager.register_process_tree(router_process)
+    set_server_ready(True)
 
-    return process_manager
+    return process_manager, http_server_process
 
 
 def _hypercorn_config_args(args: StartArgs):
@@ -413,10 +418,7 @@ def _hypercorn_config_args(args: StartArgs):
     return ["--keep-alive", "10"]
 
 
-def normal_or_p_d_start(args: StartArgs):
-    process_manager = _launch_subprocesses(args)
-
-    # 启动 Hypercorn
+def _start_http_server(args: StartArgs):
     command = [
         "hypercorn",
         *_hypercorn_config_args(args),
@@ -432,9 +434,11 @@ def normal_or_p_d_start(args: StartArgs):
         "-",
         "lightllm.server.api_http:app",
     ]
+    return subprocess.Popen(command)
 
-    # 启动子进程
-    http_server_process = subprocess.Popen(command)
+
+def normal_or_p_d_start(args: StartArgs):
+    process_manager, http_server_process = _launch_subprocesses(args)
 
     if "s3://" in args.model_dir:
         from lightllm.utils.petrel_helper import s3_model_clear

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -148,6 +148,8 @@ class StartArgs:
     audio_infer_batch_size: Optional[int] = field(default=None)
     enable_monitor_auth: bool = field(default=False)
     disable_cudagraph: bool = field(default=False)
+    startup_weight_load_mode: str = field(default="serial", metadata={"choices": ["serial", "overlap"]})
+    weight_loader_prefetch_num_threads: int = field(default=4)
     enable_prefill_cudagraph: bool = field(default=False)
     prefill_cudagraph_max_handle_token: int = field(default=8192)
     graph_max_batch_size: int = field(default=256)

--- a/lightllm/server/metrics/manager.py
+++ b/lightllm/server/metrics/manager.py
@@ -81,7 +81,15 @@ class MetricClient(threading.Thread):
     def __init__(self, port):
         super().__init__()
         self.port = port
-        self.conn = rpyc.connect("localhost", self.port)
+        deadline = time.monotonic() + 600
+        while True:
+            try:
+                self.conn = rpyc.connect("localhost", self.port)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
 
         def async_wrap(f):
             f = rpyc.async_(f)

--- a/lightllm/server/multi_level_kv_cache/cpu_cache_client.py
+++ b/lightllm/server/multi_level_kv_cache/cpu_cache_client.py
@@ -3,9 +3,13 @@ from lightllm.utils.envs_utils import get_env_start_args, get_unique_server_name
 from typing import List, Optional, Tuple
 from lightllm.utils.log_utils import init_logger
 from lightllm.common.cpu_cache import CpuCacheCreator, CpuCacheTensorSpec
+from lightllm.common.linear_att_cache_manager.config_objs import LinearAttCacheConfig
 from .shm_objs import ShmDict, ShmLinkedList, _LinkedListItem, IntList
 from lightllm.server.core.objs import AtomicShmLock
+from lightllm.utils.config_utils import is_linear_att_mixed_model
+from lightllm.utils.dist_utils import get_current_rank_in_dp
 from lightllm.utils.kv_cache_utils import calcu_cpu_cache_meta
+from lightllm.utils.startup_status import set_cpu_cache_ready, wait_cpu_cache_ready
 
 logger = init_logger(__name__)
 
@@ -17,6 +21,8 @@ class CpuKvCacheClient(object):
 
     def __init__(self, only_create_meta_data: bool, init_shm_data: bool):
         self.args = get_env_start_args()
+        if not init_shm_data:
+            wait_cpu_cache_ready()
         # to do here need calcu from from settings.
         self.kv_cache_tensor_meta = calcu_cpu_cache_meta()
         self.page_num: int = self.kv_cache_tensor_meta.page_num
@@ -37,10 +43,21 @@ class CpuKvCacheClient(object):
                 size_bytes=self.kv_cache_tensor_meta.calcu_size(),
             )
             tensor_creator = CpuCacheCreator(tensor_spec=tensor_spec)
-            self.cpu_kv_cache_tensor = tensor_creator.create_or_attach(
-                init_shm_data=init_shm_data,
-                pin=not init_shm_data,
-            )
+            pin_ranges = None
+            if not init_shm_data and is_linear_att_mixed_model(self.args.model_dir):
+                pin_ranges = LinearAttCacheConfig.load_from_args().get_cpu_cache_rank_registration_ranges(
+                    page_num=self.kv_cache_tensor_meta.page_num,
+                    tp_rank=get_current_rank_in_dp(),
+                )
+            if init_shm_data:
+                self.cpu_kv_cache_tensor = tensor_creator.create_or_attach(init_shm_data=True, pin=False)
+                self.registration_handle = None
+            else:
+                self.cpu_kv_cache_tensor, self.registration_handle = tensor_creator.create_or_attach_async(
+                    pin_ranges=pin_ranges
+                )
+        if init_shm_data:
+            set_cpu_cache_ready(True)
         return
 
     def get_one_empty_page(self, hash_key: int, disk_offload_enable: bool) -> Optional[int]:

--- a/lightllm/server/router/model_infer/mode_backend/base_backend.py
+++ b/lightllm/server/router/model_infer/mode_backend/base_backend.py
@@ -120,6 +120,11 @@ class ModeBackend:
 
         self.shared_token_load = TokenLoad(f"{get_unique_server_name()}_shared_token_load", self.dp_size_in_node)
 
+        wait_events = []
+        if self.args.enable_cpu_cache:
+            self.multi_level_cache_module = MultiLevelKvCacheModule(self)
+            wait_events.append(self.multi_level_cache_module)
+
         if self.args.enable_multimodal:
             g_infer_context.init_cpu_embed_cache_client()
 
@@ -143,6 +148,7 @@ class ModeBackend:
             "quant_cfg": kvargs.get("quant_cfg", None),
             "expert_dtype": kvargs.get("expert_dtype", None),
             "run_mode": self.run_mode,
+            "wait_events": wait_events,
         }
         self.model, self.is_multimodal = get_model(model_cfg, model_kvargs)
         self.model: TpPartBaseModel = self.model  # for easy typing
@@ -244,9 +250,6 @@ class ModeBackend:
         if self.args.mtp_mode is not None:
             self.init_mtp_draft_model(model_kvargs)
             self.init_spec_engine()
-
-        if self.args.enable_cpu_cache:
-            self.multi_level_cache_module = MultiLevelKvCacheModule(self)
 
         prof_name = f"lightllm-model_backend-node{self.node_rank}_dev{get_current_device_id()}"
         prof_mode = self.args.enable_profiling

--- a/lightllm/server/router/model_infer/mode_backend/multi_level_kv_cache.py
+++ b/lightllm/server/router/model_infer/mode_backend/multi_level_kv_cache.py
@@ -38,6 +38,9 @@ class MultiLevelKvCacheModule(object):
         self.cpu_cache_handle_queue: Deque[TransTask] = deque()
         self.cpu_cache_client = CpuKvCacheClient(only_create_meta_data=False, init_shm_data=False)
 
+    def wait(self):
+        self.cpu_cache_client.registration_handle.wait()
+
     @lru_cache()
     def need_sync_compute_stream(self) -> bool:
         """

--- a/lightllm/utils/backend_validator.py
+++ b/lightllm/utils/backend_validator.py
@@ -1,4 +1,4 @@
-"""Backend validation with subprocess isolation and ground truth checks."""
+"""Backend selection with static fast paths and isolated ground-truth fallbacks."""
 
 import multiprocessing as mp
 import os
@@ -314,10 +314,29 @@ def _run_in_subprocess(backend_name, pipe):
         devnull.close()
 
 
+def _quick_validate(backend_name: str):
+    """Use static capability checks where they are sufficient for backend selection."""
+    if backend_name == "fa3":
+        from lightllm.utils.device_utils import is_hopper
+        from lightllm.utils.sgl_utils import flash_attn_varlen_func
+
+        return is_hopper() and flash_attn_varlen_func is not None
+
+    if backend_name in ("flashinfer", "flashqla"):
+        from lightllm.utils.device_utils import has_cuda_compiler
+
+        if not has_cuda_compiler():
+            logger.info(f"Skipping {backend_name}: CUDA compiler is unavailable")
+            return False
+
+    return None
+
+
 @lru_cache(maxsize=None)
 def validate(backend_name: str) -> bool:
     if get_global_rank() == 0:
-        validate_ok = _validate(backend_name)
+        quick_result = _quick_validate(backend_name)
+        validate_ok = _validate(backend_name) if quick_result is None else quick_result
         torch.distributed.broadcast_object_list([validate_ok], src=0)
     else:
         validate_ok = [None]

--- a/lightllm/utils/backend_validator.py
+++ b/lightllm/utils/backend_validator.py
@@ -316,12 +316,6 @@ def _run_in_subprocess(backend_name, pipe):
 
 def _quick_validate(backend_name: str):
     """Use static capability checks where they are sufficient for backend selection."""
-    if backend_name == "fa3":
-        from lightllm.utils.device_utils import is_hopper
-        from lightllm.utils.sgl_utils import flash_attn_varlen_func
-
-        return is_hopper() and flash_attn_varlen_func is not None
-
     if backend_name in ("flashinfer", "flashqla"):
         from lightllm.utils.device_utils import has_cuda_compiler
 

--- a/lightllm/utils/device_utils.py
+++ b/lightllm/utils/device_utils.py
@@ -11,6 +11,16 @@ from lightllm.utils.log_utils import init_logger
 logger = init_logger(__name__)
 
 
+@lru_cache(maxsize=1)
+def has_cuda_compiler() -> bool:
+    try:
+        from torch.utils.cpp_extension import CUDA_HOME
+
+        return CUDA_HOME is not None and os.path.isfile(os.path.join(CUDA_HOME, "bin", "nvcc"))
+    except Exception:
+        return False
+
+
 @lru_cache(maxsize=None)
 def is_tesla():
     return "Tesla" in torch.cuda.get_device_name(0)

--- a/lightllm/utils/dist_check_utils.py
+++ b/lightllm/utils/dist_check_utils.py
@@ -1,14 +1,8 @@
-"""
-通过双卡 NCCL 任务，对可选的 all-reduce 快路径做环境探测。
+"""Cheap startup checks for optional all-reduce fast paths."""
 
-每个后端用 ``torch.multiprocessing.spawn(..., nprocs=2)`` 起两个子进程：
-初始化分布式后做一次真实集合通信，再退出。
-"""
+from typing import TYPE_CHECKING
 
-import socket
-import threading
-from typing import TYPE_CHECKING, Callable
-
+from lightllm.utils.device_utils import has_cuda_compiler
 from lightllm.utils.log_utils import init_logger
 
 if TYPE_CHECKING:
@@ -16,158 +10,12 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_CUSTOM_ALLREDUCE_WORLD_SIZES = (2, 4, 6, 8)
-_TWO_GPU_CHECK_TIMEOUT_SECONDS = 600.0
-
-
-def _start_two_gpu_check_timeout_watchdog(backend_name: str) -> threading.Event:
-    """Each spawned rank runs its own watchdog thread; exits the process if the check does not finish in time."""
-
-    import os
-    import time
-
-    probe_finished = threading.Event()
-
-    def watchdog_main() -> None:
-        time.sleep(_TWO_GPU_CHECK_TIMEOUT_SECONDS)
-        if not probe_finished.is_set():
-            logger.warning(
-                "%s 2-GPU all-reduce capability check timed out after %.0fs; force exit.",
-                backend_name,
-                _TWO_GPU_CHECK_TIMEOUT_SECONDS,
-            )
-            os._exit(1)
-
-    watchdog_thread = threading.Thread(target=watchdog_main, daemon=True)
-    watchdog_thread.start()
-    return probe_finished
-
-
-def _should_run_allreduce_capability_check(args: "StartArgs") -> bool:
-    if args.hardware_platform != "cuda":
-        return False
-
-    return (args.tp // args.dp) in _CUSTOM_ALLREDUCE_WORLD_SIZES
-
-
-def _pick_free_tcp_port() -> int:
-    socket_handle = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_handle.bind(("127.0.0.1", 0))
-    free_port = socket_handle.getsockname()[1]
-    socket_handle.close()
-    return int(free_port)
-
-
-def _flashinfer_two_gpu_check_worker(process_rank: int, init_tcp_port: int) -> None:
-    probe_finished_event = _start_two_gpu_check_timeout_watchdog("FlashInfer")
-    try:
-        import torch
-        import torch.distributed as dist
-
-        cuda_device = torch.device(f"cuda:{process_rank}")
-        torch.cuda.set_device(cuda_device)
-        dist.init_process_group(
-            "nccl",
-            init_method=f"tcp://127.0.0.1:{init_tcp_port}",
-            world_size=2,
-            rank=process_rank,
-            device_id=cuda_device,
-        )
-        try:
-            gloo_process_group = dist.new_group([0, 1], backend="gloo")
-            from lightllm.distributed.flashinfer_all_reduce import FlashInferAllReduce
-
-            flashinfer_all_reduce = FlashInferAllReduce(gloo_process_group, cuda_device)
-            if flashinfer_all_reduce.disabled:
-                raise RuntimeError("FlashInferAllReduce disabled")
-            if process_rank == 0:
-                input_tensor = torch.zeros(2, 64, device=cuda_device, dtype=torch.bfloat16)
-            else:
-                input_tensor = torch.ones(2, 64, device=cuda_device, dtype=torch.bfloat16)
-            if not flashinfer_all_reduce.should_use(input_tensor):
-                raise RuntimeError("FlashInferAllReduce unsupported for probe tensor")
-            output_tensor = flashinfer_all_reduce.all_reduce(input_tensor)
-            dist.barrier()
-            expected_reduced = torch.ones(2, 64, device=cuda_device, dtype=torch.bfloat16)
-            if not torch.allclose(output_tensor, expected_reduced):
-                raise RuntimeError("FlashInfer allreduce value mismatch")
-        finally:
-            if dist.is_initialized():
-                dist.destroy_process_group()
-    finally:
-        probe_finished_event.set()
-
-
-def _symm_mem_two_gpu_check_worker(process_rank: int, init_tcp_port: int) -> None:
-    probe_finished_event = _start_two_gpu_check_timeout_watchdog("SymmMem")
-    try:
-        import torch
-        import torch.distributed as dist
-
-        cuda_device = torch.device(f"cuda:{process_rank}")
-        torch.cuda.set_device(cuda_device)
-        dist.init_process_group(
-            "nccl",
-            init_method=f"tcp://127.0.0.1:{init_tcp_port}",
-            world_size=2,
-            rank=process_rank,
-            device_id=cuda_device,
-        )
-        try:
-            nccl_process_group = dist.new_group([0, 1], backend="nccl")
-            from lightllm.distributed.symm_mem_all_reduce import SymmMemAllreduce
-
-            symm_mem_all_reduce = SymmMemAllreduce(nccl_process_group, cuda_device, dtype=torch.bfloat16)
-            if symm_mem_all_reduce.disabled:
-                raise RuntimeError("SymmMemAllreduce disabled")
-            if process_rank == 0:
-                activation_tensor = torch.zeros(8, 32, device=cuda_device, dtype=torch.bfloat16)
-            else:
-                activation_tensor = torch.ones(8, 32, device=cuda_device, dtype=torch.bfloat16)
-            symm_mem_all_reduce.all_reduce(activation_tensor)
-            dist.barrier()
-            expected_reduced = torch.ones(8, 32, device=cuda_device, dtype=torch.bfloat16)
-            if not torch.allclose(activation_tensor, expected_reduced):
-                raise RuntimeError("SymmMem allreduce value mismatch")
-        finally:
-            if dist.is_initialized():
-                dist.destroy_process_group()
-    finally:
-        probe_finished_event.set()
-
-
-def _check_ok_two_gpu_all_reduce(worker_entry: Callable[[int, int], None], init_tcp_port: int) -> bool:
-    import torch.multiprocessing as torch_mp
-
-    try:
-        torch_mp.spawn(worker_entry, args=(init_tcp_port,), nprocs=2, join=True)
-        return True
-    except Exception as error:
-        error_str = str(error)
-        error_str = error_str[-66:].replace("\n", "")
-        logger.warning("2-GPU all-reduce capability check failed for %s: %s", worker_entry.__name__, error_str)
-        return False
-
 
 def auto_configure_allreduce_flags_from_args(args: "StartArgs") -> None:
-    """
-    用户若已通过 ``--disable_*`` 关闭某后端，则不再处理该后端。
-
-    否则会按环境与并行规模，对每个后端做一次双进程 NCCL 探测；失败则将对应 ``disable_*`` 设为 True。
-
-    会就地修改 ``args.disable_flashinfer_allreduce`` / ``args.disable_symm_mem_allreduce``。
-    """
-    if not _should_run_allreduce_capability_check(args):
+    """Keep correctness fallbacks local to the real process group instead of probing two GPUs."""
+    if args.hardware_platform != "cuda":
         return
 
-    if not args.disable_flashinfer_allreduce:
-        if not _check_ok_two_gpu_all_reduce(_flashinfer_two_gpu_check_worker, _pick_free_tcp_port()):
-            logger.info(
-                "Auto-set disable_flashinfer_allreduce=True (2-GPU FlashInfer all-reduce capability check failed)."
-            )
-            args.disable_flashinfer_allreduce = True
-
-    if not args.disable_symm_mem_allreduce:
-        if not _check_ok_two_gpu_all_reduce(_symm_mem_two_gpu_check_worker, _pick_free_tcp_port()):
-            logger.info("Auto-set disable_symm_mem_allreduce=True (2-GPU SymmMem all-reduce capability check failed).")
-            args.disable_symm_mem_allreduce = True
+    if not args.disable_flashinfer_allreduce and not has_cuda_compiler():
+        args.disable_flashinfer_allreduce = True
+        logger.info("Auto-set disable_flashinfer_allreduce=True because the CUDA compiler is unavailable.")

--- a/lightllm/utils/kv_cache_utils.py
+++ b/lightllm/utils/kv_cache_utils.py
@@ -393,9 +393,7 @@ def register_shm_ptr_to_pin_async(
 
 
 @lru_cache(maxsize=None)
-def register_shm_ptr_to_pin(
-    shm_ptr: int, size: int, ranges: Optional[Tuple[Tuple[int, int], ...]] = None
-) -> int:
+def register_shm_ptr_to_pin(shm_ptr: int, size: int, ranges: Optional[Tuple[Tuple[int, int], ...]] = None) -> int:
     """Synchronously cudaHostRegister selected ranges of a shared-memory allocation."""
     return _register_shm_ptr_to_pin(shm_ptr=shm_ptr, size=size, ranges=ranges)
 

--- a/lightllm/utils/kv_cache_utils.py
+++ b/lightllm/utils/kv_cache_utils.py
@@ -245,16 +245,47 @@ def create_shm_kv_cache_ptr(key: int, size: int) -> int:
     return shm_addr
 
 
-@lru_cache(maxsize=None)
-def register_shm_ptr_to_pin(shm_ptr: int, size: int) -> int:
-    """Synchronously cudaHostRegister the given [shm_ptr, shm_ptr+size)."""
+def _normalize_registration_ranges(
+    size: int, ranges: Optional[Tuple[Tuple[int, int], ...]], page_size: Optional[int] = None
+) -> Tuple[Tuple[int, int], ...]:
+    if ranges is None:
+        return ((0, size),)
+
+    page_size = page_size or os.sysconf("SC_PAGE_SIZE")
+    normalized = []
+    for offset, length in ranges:
+        if offset < 0 or length <= 0 or offset + length > size:
+            raise ValueError(f"invalid registration range: offset={offset}, length={length}, size={size}")
+        start = (offset // page_size) * page_size
+        end = min(size, triton.cdiv(offset + length, page_size) * page_size)
+        normalized.append((start, end))
+
+    normalized.sort()
+    merged = []
+    for start, end in normalized:
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return tuple((start, end - start) for start, end in merged)
+
+
+def _register_shm_ptr_to_pin(
+    shm_ptr: int,
+    size: int,
+    ranges: Optional[Tuple[Tuple[int, int], ...]],
+    handle: Optional["AsyncRegistrationHandle"] = None,
+) -> int:
     chunk_bytes = 128 * 1024 * 1024  # 128M性能最好
     tasks: list[tuple[int, int]] = []
-    offset = 0
-    while offset < size:
-        seg_len = min(chunk_bytes, size - offset)
-        tasks.append((offset, seg_len))
-        offset += seg_len
+    registration_ranges = _normalize_registration_ranges(size=size, ranges=ranges)
+    for range_offset, range_size in registration_ranges:
+        offset = range_offset
+        range_end = range_offset + range_size
+        while offset < range_end:
+            seg_len = min(chunk_bytes, range_end - offset)
+            tasks.append((offset, seg_len))
+            offset += seg_len
 
     cuda = ctypes.CDLL("/usr/local/cuda/targets/x86_64-linux/lib/libcudart.so")
     cuda.cudaHostRegister.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint]
@@ -275,23 +306,98 @@ def register_shm_ptr_to_pin(shm_ptr: int, size: int) -> int:
         r = cuda.cudaHostRegister(ptr, ctypes.c_size_t(seg_len), cudaHostRegisterFlag)
         if r != 0:
             raise Exception(f"cudaHostRegister failed with error code {r}, prefer to use hugetlb")
-        return
+        return offset
 
     # worker_num的数值需要与_pre_warm_memory一致，不然会丢失warmup的效果
-    if tasks:
-        worker_num = min(8, len(tasks))
-        with concurrent.futures.ThreadPoolExecutor(max_workers=worker_num) as executor:
-            futures = [executor.submit(_register_one_segment, task) for task in tasks]
-            for future in tqdm(concurrent.futures.as_completed(futures), total=len(futures), desc=desc):
-                future.result()
+    worker_num = min(8, len(tasks))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_num) as executor:
+        futures = [executor.submit(_register_one_segment, task) for task in tasks]
+        completed = concurrent.futures.as_completed(futures)
+        if handle is None:
+            completed = tqdm(completed, total=len(futures), desc=desc)
 
-    device_ptr = ctypes.c_void_p()
-    host_ptr = ctypes.c_void_p(shm_ptr)
-    res = cuda.cudaHostGetDevicePointer(ctypes.byref(device_ptr), host_ptr, 0)
-    if res != 0:
-        raise Exception(f"cudaHostGetDevicePointer failed with error code {res}")
-    logger.info(f"cudaHostGetDevicePointer success, host_ptr={host_ptr.value}, device_ptr={device_ptr.value}")
-    return device_ptr.value
+        device_base_ptr = None
+        for future in completed:
+            registered_offset = future.result()
+            if device_base_ptr is None:
+                device_ptr = ctypes.c_void_p()
+                host_ptr = ctypes.c_void_p(shm_ptr + registered_offset)
+                res = cuda.cudaHostGetDevicePointer(ctypes.byref(device_ptr), host_ptr, 0)
+                if res != 0:
+                    raise Exception(f"cudaHostGetDevicePointer failed with error code {res}")
+                device_base_ptr = device_ptr.value - registered_offset
+                if handle is not None:
+                    handle._set_device_ptr(device_base_ptr)
+
+            if handle is not None:
+                handle.completed_tasks += 1
+
+    registered_bytes = sum(range_size for _, range_size in registration_ranges)
+    logger.info(
+        f"cudaHostRegister success, device_base_ptr={device_base_ptr}, "
+        f"registered_bytes={registered_bytes}, total_bytes={size}, ranges={len(registration_ranges)}"
+    )
+    return device_base_ptr
+
+
+class AsyncRegistrationHandle:
+    def __init__(self, total_tasks: int):
+        self.total_tasks = total_tasks
+        self.completed_tasks = 0
+        self.device_ptr: Optional[int] = None
+        self._exception: Optional[BaseException] = None
+        self._device_ptr_ready = threading.Event()
+        self._finished = threading.Event()
+
+    def _set_device_ptr(self, device_ptr: int):
+        self.device_ptr = device_ptr
+        self._device_ptr_ready.set()
+
+    def _set_exception(self, exception: BaseException):
+        self._exception = exception
+        self._device_ptr_ready.set()
+        self._finished.set()
+
+    def wait_for_device_ptr(self) -> int:
+        self._device_ptr_ready.wait()
+        if self._exception is not None:
+            raise self._exception
+        assert self.device_ptr is not None
+        return self.device_ptr
+
+    def wait(self) -> int:
+        self._finished.wait()
+        if self._exception is not None:
+            raise self._exception
+        assert self.device_ptr is not None
+        return self.device_ptr
+
+
+def register_shm_ptr_to_pin_async(
+    shm_ptr: int, size: int, ranges: Optional[Tuple[Tuple[int, int], ...]] = None
+) -> AsyncRegistrationHandle:
+    registration_ranges = _normalize_registration_ranges(size=size, ranges=ranges)
+    chunk_bytes = 128 * 1024 * 1024
+    total_tasks = sum(triton.cdiv(range_size, chunk_bytes) for _, range_size in registration_ranges)
+    handle = AsyncRegistrationHandle(total_tasks=total_tasks)
+
+    def _worker():
+        try:
+            _register_shm_ptr_to_pin(shm_ptr=shm_ptr, size=size, ranges=ranges, handle=handle)
+            handle._finished.set()
+        except BaseException as exception:
+            handle._set_exception(exception)
+
+    threading.Thread(target=_worker, name=f"cpu_cache_register_{shm_ptr}", daemon=True).start()
+    return handle
+
+
+@lru_cache(maxsize=None)
+def register_shm_ptr_to_pin(
+    shm_ptr: int, size: int, ranges: Optional[Tuple[Tuple[int, int], ...]] = None
+) -> int:
+    """Synchronously cudaHostRegister selected ranges of a shared-memory allocation."""
+    return _register_shm_ptr_to_pin(shm_ptr=shm_ptr, size=size, ranges=ranges)
 
 
 @lru_cache(maxsize=None)

--- a/lightllm/utils/startup_status.py
+++ b/lightllm/utils/startup_status.py
@@ -1,0 +1,35 @@
+from functools import lru_cache
+import time
+
+from lightllm.server.router.dynamic_prompt.shared_arr import SharedInt
+from lightllm.utils.envs_utils import get_unique_server_name
+
+
+@lru_cache(maxsize=1)
+def _server_ready_flag():
+    return SharedInt(f"{get_unique_server_name()}_server_ready")
+
+
+def set_server_ready(ready: bool):
+    _server_ready_flag().set_value(int(ready))
+
+
+def is_server_ready() -> bool:
+    return bool(_server_ready_flag().get_value())
+
+
+@lru_cache(maxsize=1)
+def _cpu_cache_ready_flag():
+    return SharedInt(f"{get_unique_server_name()}_cpu_cache_ready")
+
+
+def set_cpu_cache_ready(ready: bool):
+    _cpu_cache_ready_flag().set_value(int(ready))
+
+
+def wait_cpu_cache_ready(timeout_seconds: float = 600):
+    deadline = time.monotonic() + timeout_seconds
+    while not _cpu_cache_ready_flag().get_value():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Timed out waiting for the CPU cache manager")
+        time.sleep(0.01)

--- a/test/utils/test_cpu_cache_registration.py
+++ b/test/utils/test_cpu_cache_registration.py
@@ -5,11 +5,14 @@ from lightllm.utils.kv_cache_utils import _normalize_registration_ranges
 
 
 def test_normalize_registration_ranges_aligns_and_merges():
-    assert _normalize_registration_ranges(
-        size=32 * 1024,
-        ranges=((4097, 4095), (8192, 4096), (20 * 1024, 1)),
-        page_size=4096,
-    ) == ((4096, 8192), (20 * 1024, 4096))
+    assert (
+        _normalize_registration_ranges(
+            size=32 * 1024,
+            ranges=((4097, 4095), (8192, 4096), (20 * 1024, 1)),
+            page_size=4096,
+        )
+        == ((4096, 8192), (20 * 1024, 4096))
+    )
     assert _normalize_registration_ranges(size=5000, ranges=((4999, 1),), page_size=4096) == ((4096, 904),)
 
     with pytest.raises(ValueError, match="invalid registration range"):

--- a/test/utils/test_cpu_cache_registration.py
+++ b/test/utils/test_cpu_cache_registration.py
@@ -1,0 +1,40 @@
+import pytest
+
+from lightllm.common.linear_att_cache_manager.config_objs import LinearAttCacheConfig
+from lightllm.utils.kv_cache_utils import _normalize_registration_ranges
+
+
+def test_normalize_registration_ranges_aligns_and_merges():
+    assert _normalize_registration_ranges(
+        size=32 * 1024,
+        ranges=((4097, 4095), (8192, 4096), (20 * 1024, 1)),
+        page_size=4096,
+    ) == ((4096, 8192), (20 * 1024, 4096))
+    assert _normalize_registration_ranges(size=5000, ranges=((4999, 1),), page_size=4096) == ((4096, 904),)
+
+    with pytest.raises(ValueError, match="invalid registration range"):
+        _normalize_registration_ranges(size=4096, ranges=((4096, 1),), page_size=4096)
+
+
+def test_linear_cache_registers_only_current_tp_rank_ranges():
+    config = object.__new__(LinearAttCacheConfig)
+    config.tp_world_size = 4
+    config.full_att_all_num_kv_heads = 4
+    config.get_cpu_cache_full_att_bytes = lambda: 16 * 4096
+    config.get_cpu_cache_conv_bytes = lambda: 8 * 4096
+    config.get_cpu_cache_ssm_bytes = lambda: 4 * 4096
+    config.get_cpu_cache_big_page_bytes = lambda: 28 * 4096
+
+    ranges = config.get_cpu_cache_rank_registration_ranges(page_num=2, tp_rank=2)
+
+    assert ranges[:3] == ((0, 1), (16 * 4096, 1), (24 * 4096, 1))
+    assert ranges[3:] == (
+        (8 * 4096, 4 * 4096),
+        (20 * 4096, 2 * 4096),
+        (26 * 4096, 4096),
+        (36 * 4096, 4 * 4096),
+        (48 * 4096, 2 * 4096),
+        (54 * 4096, 4096),
+    )
+    normalized = _normalize_registration_ranges(size=2 * 28 * 4096, ranges=ranges, page_size=4096)
+    assert sum(length for _, length in normalized) == 2 * 28 * 4096 // 4 + 3 * 4096

--- a/test/utils/test_fast_backend_checks.py
+++ b/test/utils/test_fast_backend_checks.py
@@ -9,6 +9,7 @@ def test_jit_backends_are_skipped_without_cuda_compiler(monkeypatch):
 
     assert backend_validator._quick_validate("flashinfer") is False
     assert backend_validator._quick_validate("flashqla") is False
+    assert backend_validator._quick_validate("fa3") is None
     assert backend_validator._quick_validate("triton") is None
 
 

--- a/test/utils/test_fast_backend_checks.py
+++ b/test/utils/test_fast_backend_checks.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from lightllm.utils import backend_validator
+from lightllm.utils import dist_check_utils
+
+
+def test_jit_backends_are_skipped_without_cuda_compiler(monkeypatch):
+    monkeypatch.setattr("lightllm.utils.device_utils.has_cuda_compiler", lambda: False)
+
+    assert backend_validator._quick_validate("flashinfer") is False
+    assert backend_validator._quick_validate("flashqla") is False
+    assert backend_validator._quick_validate("triton") is None
+
+
+def test_allreduce_check_uses_runtime_fallback(monkeypatch):
+    monkeypatch.setattr(dist_check_utils, "has_cuda_compiler", lambda: False)
+    args = SimpleNamespace(
+        hardware_platform="cuda",
+        disable_flashinfer_allreduce=False,
+        disable_symm_mem_allreduce=False,
+    )
+
+    dist_check_utils.auto_configure_allreduce_flags_from_args(args)
+
+    assert args.disable_flashinfer_allreduce is True
+    assert args.disable_symm_mem_allreduce is False

--- a/test/utils/test_optional_allreduce_consensus.py
+++ b/test/utils/test_optional_allreduce_consensus.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from lightllm.distributed import communication_op
+from lightllm.distributed import flashinfer_all_reduce
+
+
+def test_optional_allreduce_requires_every_rank(monkeypatch):
+    group = communication_op.CustomProcessGroup.__new__(communication_op.CustomProcessGroup)
+    group.optional_allreduce_group = object()
+
+    def reject_on_peer(enabled, op, group):
+        assert enabled.device.type == "cpu"
+        assert op == communication_op.dist.ReduceOp.MIN
+        enabled.zero_()
+
+    monkeypatch.setattr(communication_op, "has_nvlink", lambda: True)
+    monkeypatch.setattr(communication_op.dist, "all_reduce", reject_on_peer)
+
+    assert group._support_custom_allreduce() is False
+
+
+def test_optional_allreduce_skips_consensus_for_unsupported_world_size(monkeypatch):
+    group = communication_op.CustomProcessGroup.__new__(communication_op.CustomProcessGroup)
+    group.optional_allreduce_group = None
+    monkeypatch.setattr(
+        communication_op.dist,
+        "all_reduce",
+        lambda *args, **kwargs: pytest.fail("consensus should not run"),
+    )
+
+    assert group._support_custom_allreduce() is False
+
+
+def test_flashinfer_workspace_failure_disables_every_rank(monkeypatch):
+    destroyed = []
+
+    class Workspace:
+        def destroy(self):
+            destroyed.append(True)
+
+    reducer = flashinfer_all_reduce.FlashInferAllReduce.__new__(flashinfer_all_reduce.FlashInferAllReduce)
+    reducer._workspace = None
+    reducer._ws_hidden_dim = None
+    reducer._ws_dtype = None
+    reducer._ws_max_token_num = 0
+    reducer.max_workspace_size = 1024
+    reducer.world_size = 2
+    reducer.rank = 0
+    reducer.group = object()
+    reducer.disabled = False
+
+    fake_comm = SimpleNamespace(create_allreduce_fusion_workspace=lambda **kwargs: Workspace())
+
+    def reject_on_peer(enabled, op, group):
+        enabled.zero_()
+
+    monkeypatch.setattr(flashinfer_all_reduce, "flashinfer_comm", fake_comm)
+    monkeypatch.setattr(flashinfer_all_reduce, "TorchDistBackend", lambda group: object())
+    monkeypatch.setattr(flashinfer_all_reduce.dist, "all_reduce", reject_on_peer)
+
+    assert reducer._ensure_workspace(hidden_dim=16, dtype=torch.float16) is False
+    assert reducer.disabled is True
+    assert reducer._workspace is None
+    assert destroyed == [True]

--- a/test/utils/test_startup_weight_load.py
+++ b/test/utils/test_startup_weight_load.py
@@ -1,0 +1,91 @@
+import argparse
+
+import pytest
+import torch
+
+from lightllm.common.basemodel.layer_weights.meta_weights.base_weight import BaseWeight
+from lightllm.common.basemodel.layer_weights.startup_weight_load import (
+    CAPTURE_SAFE_WEIGHT_SENTINEL,
+    WeightStorageManifest,
+    initialize_capture_safe_weights,
+    start_checkpoint_prefetch,
+)
+from lightllm.server.api_cli import add_cli_args
+
+
+class DummyWeight(BaseWeight):
+    def __init__(self):
+        self.weight = torch.empty(8)
+
+    def load_hf_weights(self, weights):
+        self.weight.copy_(weights["weight"])
+
+    def _create_weight(self):
+        return
+
+    def verify_load(self):
+        return True
+
+
+class DummyLayer:
+    def __init__(self):
+        self.projection = DummyWeight()
+
+
+def test_capture_weights_can_be_committed_in_place():
+    layer = DummyLayer()
+    initialize_capture_safe_weights(layer, [], device_type="cpu")
+    assert torch.all(layer.projection.weight == CAPTURE_SAFE_WEIGHT_SENTINEL)
+
+    manifest = WeightStorageManifest.capture(layer, [], device_type="cpu")
+    layer.projection.load_hf_weights({"weight": torch.arange(8)})
+
+    assert manifest.changed_names(layer, []) == ()
+    assert manifest.unchanged_floating_names(CAPTURE_SAFE_WEIGHT_SENTINEL) == ()
+
+
+def test_storage_manifest_rejects_tensor_replacement():
+    layer = DummyLayer()
+    manifest = WeightStorageManifest.capture(layer, [], device_type="cpu")
+    layer.projection.weight = layer.projection.weight.clone()
+
+    assert manifest.changed_names(layer, []) == ("pre_post.projection.weight",)
+
+
+def test_checkpoint_prefetch_reads_local_safetensors(tmp_path):
+    for index in range(3):
+        (tmp_path / f"model-{index}.safetensors").write_bytes(b"checkpoint" * 1024)
+
+    handle = start_checkpoint_prefetch(
+        weight_dir=str(tmp_path),
+        num_threads=2,
+        rank_in_node=0,
+        node_world_size=1,
+    )
+    handle.wait(timeout=5)
+
+    assert handle.done
+    assert handle.errors == ()
+
+
+def test_checkpoint_prefetch_requires_safetensors(tmp_path):
+    (tmp_path / "pytorch_model.bin").write_bytes(b"checkpoint")
+
+    with pytest.raises(ValueError, match="safetensors"):
+        start_checkpoint_prefetch(str(tmp_path), num_threads=1, rank_in_node=0, node_world_size=1)
+
+
+def test_startup_weight_load_cli_defaults_to_serial():
+    args = add_cli_args(argparse.ArgumentParser()).parse_args([])
+
+    assert args.startup_weight_load_mode == "serial"
+    assert args.weight_loader_prefetch_num_threads == 4
+
+
+def test_startup_weight_load_cli_accepts_overlap():
+    args = add_cli_args(argparse.ArgumentParser()).parse_args(
+        ["--startup_weight_load_mode", "overlap", "--weight_loader_prefetch_num_threads", "8"]
+    )
+
+    assert args.startup_weight_load_mode == "overlap"
+    assert args.weight_loader_prefetch_num_threads == 8


### PR DESCRIPTION
## Summary

- register only the CPU cache ranges accessed by each TP rank instead of registering the full shared allocation in every rank
- overlap asynchronous host-memory registration with model weight loading
- start the CPU cache manager, metrics, router, and detokenizer in parallel while gating health/readiness until initialization completes
- eagerly capture only the first CUDA graph batch size and capture remaining sizes on demand
- replace expensive two-GPU/backend preflight processes with cheap capability checks and runtime fallbacks

## Performance

Measured with Qwen3.8-27B, TP4, and a 128 GiB CPU cache using the same server arguments before and after this change:

| Metric | Before | After |
| --- | ---: | ---: |
| Time to healthy | ~393 s | ~128 s |
| Startup speedup | 1.00x | **3.07x** |
| Registered bytes per TP rank | 133.47 GB | 33.37 GB |
| Host registration per rank | ~24 s | 4-5 s, overlapped with weight loading |

The selective registration keeps small logical-base anchor pages because Triton validates each strided tensor view's base pointer before launching the cache transfer kernels.

## Validation

- `PYTHONPATH=. pytest -q test/utils/test_cpu_cache_registration.py test/utils/test_fast_backend_checks.py test/test_api/test_server_busy_handling.py test/kernel/test_build_chained_mtp_decode_input.py` — 18 passed
- `python -m compileall -q lightllm`
- `git diff --check`
- successful completion requests after startup
- verified on-demand CUDA graph capture and replay
- filled GPU prompt cache with five distinct 65,537-token prefixes, then verified that the evicted prefix reloaded 65,536 tokens with `cpu cache hit: True`

## Trade-off

The first request for a previously unseen CUDA graph batch size pays the one-time graph capture cost; subsequent requests replay the captured graph normally.
