### PR TITLE
fix(api): return 400 for pre-stream length errors

### DIFF
--- a/docs/CN/source/tutorial/api_server_args.rst
+++ b/docs/CN/source/tutorial/api_server_args.rst
@@ -40,6 +40,11 @@ APIServer 参数详解
 
     HTTP 服务器工作进程数，默认为 ``1``
 
+.. option:: --disable_delay_response_start
+
+    立即发送流式响应的状态码和响应头，不再等待首个响应 chunk 就绪。默认情况下，LightLLM 会延迟发送
+    响应起始事件，使首个 chunk 产生前抛出的异常仍能返回正确的 HTTP 状态码。
+
 .. option:: --hypercorn_config
 
     Hypercorn TOML 配置文件路径，仅支持 TOML 格式。示例文件见 ``test/hypercorn_config.toml``。

--- a/docs/EN/source/tutorial/api_server_args.rst
+++ b/docs/EN/source/tutorial/api_server_args.rst
@@ -40,6 +40,12 @@ Basic Configuration Parameters
 
     HTTP server worker process count, default is ``1``
 
+.. option:: --disable_delay_response_start
+
+    Send the status and headers of a streaming response immediately instead of waiting until the first response
+    chunk is ready. By default, LightLLM delays the response start so errors raised before the first chunk can still
+    be returned with the appropriate HTTP status code.
+
 .. option:: --hypercorn_config
 
     Path to a Hypercorn TOML configuration file. Only TOML configuration files are supported.

--- a/lightllm/server/api_cli.py
+++ b/lightllm/server/api_cli.py
@@ -35,6 +35,14 @@ def add_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--httpserver_workers", type=int, default=1)
     parser.add_argument(
+        "--disable_delay_response_start",
+        action="store_true",
+        help=(
+            "Send streaming response status and headers immediately instead of waiting until the first "
+            "response chunk is ready."
+        ),
+    )
+    parser.add_argument(
         "--hypercorn_config",
         type=str,
         default=None,

--- a/lightllm/server/api_errors.py
+++ b/lightllm/server/api_errors.py
@@ -5,7 +5,10 @@ from typing import Any, Mapping
 
 from fastapi.responses import JSONResponse
 
-from lightllm.utils.error_utils import ServerBusyError
+from lightllm.utils.error_utils import SERVER_BUSY_MESSAGE, ServerBusyError
+from lightllm.utils.log_utils import init_logger
+
+logger = init_logger(__name__)
 
 _RATE_LIMIT_ERROR_TYPES = {"RateLimitError", "rate_limit_error"}
 
@@ -37,4 +40,5 @@ def create_error_response(
 
 
 def create_server_busy_response(exc: ServerBusyError) -> JSONResponse:
-    return create_error_response(HTTPStatus(exc.status_code), str(exc))
+    logger.debug("Server busy detail: %s", exc.message)
+    return create_error_response(HTTPStatus(exc.status_code), SERVER_BUSY_MESSAGE)

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -46,7 +46,7 @@ from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args
 from lightllm.utils.log_utils import init_logger
-from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, ServerBusyError
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.envs_utils import get_unique_server_name
 from lightllm.utils.shm_port_args import get_shm_port_args
@@ -168,6 +168,17 @@ async def server_busy_exception_handler(request: Request, exc: ServerBusyError) 
         return _anthropic_error_response(HTTPStatus(exc.status_code), str(exc))
 
     return create_server_busy_response(exc)
+
+
+@app.exception_handler(InvalidRequestError)
+async def invalid_request_exception_handler(request: Request, exc: InvalidRequestError) -> JSONResponse:
+    if request.url.path == "/v1/messages":
+        from .api_anthropic import _anthropic_error_response
+
+        g_objs.metric_client.counter_inc("lightllm_request_failure")
+        return _anthropic_error_response(HTTPStatus.BAD_REQUEST, str(exc))
+
+    return create_error_response(HTTPStatus.BAD_REQUEST, str(exc))
 
 
 @app.get("/liveness")

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -156,7 +156,7 @@ app.add_middleware(_AccessLogMiddleware)
 
 @app.exception_handler(ServerBusyError)
 async def server_busy_exception_handler(request: Request, exc: ServerBusyError) -> JSONResponse:
-    logger.debug("Server busy detail: %s", exc.message)
+    logger.warning("Server busy detail: %s", exc.message)
 
     # Streaming responses can raise during their first body iteration, after
     # the route handler has already returned. Preserve the Anthropic error

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -46,7 +46,7 @@ from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args
 from lightllm.utils.log_utils import init_logger
-from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, SERVER_BUSY_MESSAGE, ServerBusyError
 from lightllm.server.metrics.manager import MetricClient
 from lightllm.utils.envs_utils import get_unique_server_name
 from lightllm.utils.shm_port_args import get_shm_port_args
@@ -156,7 +156,7 @@ app.add_middleware(_AccessLogMiddleware)
 
 @app.exception_handler(ServerBusyError)
 async def server_busy_exception_handler(request: Request, exc: ServerBusyError) -> JSONResponse:
-    logger.warning(str(exc))
+    logger.debug("Server busy detail: %s", exc.message)
 
     # Streaming responses can raise during their first body iteration, after
     # the route handler has already returned. Preserve the Anthropic error
@@ -165,7 +165,7 @@ async def server_busy_exception_handler(request: Request, exc: ServerBusyError) 
         from .api_anthropic import _anthropic_error_response
 
         g_objs.metric_client.counter_inc("lightllm_request_failure")
-        return _anthropic_error_response(HTTPStatus(exc.status_code), str(exc))
+        return _anthropic_error_response(HTTPStatus(exc.status_code), SERVER_BUSY_MESSAGE)
 
     return create_server_busy_response(exc)
 
@@ -304,7 +304,7 @@ async def generate(request: Request) -> Response:
     try:
         return await g_objs.g_generate_func(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -326,7 +326,7 @@ async def generate_stream(request: Request) -> Response:
     try:
         return await g_objs.g_generate_stream_func(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -348,7 +348,7 @@ async def get_score(request: Request) -> Response:
     try:
         return await lightllm_get_score(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -384,7 +384,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -404,7 +404,7 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -423,9 +423,9 @@ async def anthropic_messages(raw_request: Request) -> Response:
     try:
         return await anthropic_messages_impl(raw_request)
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         g_objs.metric_client.counter_inc("lightllm_request_failure")
-        return _anthropic_error_response(HTTPStatus(e.status_code), str(e))
+        return _anthropic_error_response(HTTPStatus(e.status_code), SERVER_BUSY_MESSAGE)
     except ClientDisconnected as e:
         logger.warning(str(e))
         return Response(status_code=499)
@@ -456,7 +456,7 @@ async def openai_responses(raw_request: Request) -> Response:
     try:
         return await responses_impl(raw_request)
     except ServerBusyError as e:
-        logger.warning(str(e))
+        logger.debug("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))

--- a/lightllm/server/api_http.py
+++ b/lightllm/server/api_http.py
@@ -304,7 +304,7 @@ async def generate(request: Request) -> Response:
     try:
         return await g_objs.g_generate_func(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -326,7 +326,7 @@ async def generate_stream(request: Request) -> Response:
     try:
         return await g_objs.g_generate_stream_func(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -348,7 +348,7 @@ async def get_score(request: Request) -> Response:
     try:
         return await lightllm_get_score(request, g_objs.httpserver_manager)
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -384,7 +384,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -404,7 +404,7 @@ async def completions(request: CompletionRequest, raw_request: Request) -> Respo
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ClientDisconnected as e:
         logger.warning(str(e))
@@ -423,7 +423,7 @@ async def anthropic_messages(raw_request: Request) -> Response:
     try:
         return await anthropic_messages_impl(raw_request)
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         g_objs.metric_client.counter_inc("lightllm_request_failure")
         return _anthropic_error_response(HTTPStatus(e.status_code), SERVER_BUSY_MESSAGE)
     except ClientDisconnected as e:
@@ -456,7 +456,7 @@ async def openai_responses(raw_request: Request) -> Response:
     try:
         return await responses_impl(raw_request)
     except ServerBusyError as e:
-        logger.debug("Server busy detail: %s", e.message)
+        logger.warning("Server busy detail: %s", e.message)
         return create_server_busy_response(e)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -75,9 +75,13 @@ async def _safe_stream_wrapper(stream_generator):
             raise
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
+        yield "data: [DONE]\n\n"
     except ValueError as e:
+        if not first_chunk_sent:
+            raise
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
+        yield "data: [DONE]\n\n"
     except ServerBusyError as e:
         logger.debug("Server busy detail: %s", e.message)
         if not first_chunk_sent:

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -30,7 +30,7 @@ from .httpserver.manager import HttpServerManager
 from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
-from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, SERVER_BUSY_MESSAGE, ServerBusyError
 
 from lightllm.utils.log_utils import init_logger
 from lightllm.server.metrics.manager import MetricClient
@@ -80,7 +80,13 @@ async def _safe_stream_wrapper(stream_generator):
         yield f"data: {error_data}\n\n"
     except ServerBusyError as e:
         logger.debug("Server busy detail: %s", e.message)
-        raise
+        if not first_chunk_sent:
+            raise
+        error_data = json.dumps(
+            {"error": {"message": SERVER_BUSY_MESSAGE, "type": "server_error", "code": "stream_error"}},
+            ensure_ascii=False,
+        )
+        yield f"data: {error_data}\n\n"
     except ClientDisconnected as e:
         logger.warning(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -87,6 +87,7 @@ async def _safe_stream_wrapper(stream_generator):
             ensure_ascii=False,
         )
         yield f"data: {error_data}\n\n"
+        yield "data: [DONE]\n\n"
     except ClientDisconnected as e:
         logger.warning(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -78,7 +78,11 @@ async def _safe_stream_wrapper(stream_generator):
         yield "data: [DONE]\n\n"
     except ValueError as e:
         if not first_chunk_sent:
-            raise
+            # Request setup is lazy for streaming responses, so validation
+            # errors raised here bypass the endpoint's normal ValueError
+            # handler. Convert them to the dedicated request-error type so
+            # the application-level handler returns HTTP 400.
+            raise InvalidRequestError(str(e)) from e
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
         yield "data: [DONE]\n\n"

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -79,14 +79,8 @@ async def _safe_stream_wrapper(stream_generator):
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"
     except ServerBusyError as e:
-        if not first_chunk_sent:
-            raise
-        logger.error("Generation interrupted after the stream started: %s", e.message)
-        error_data = json.dumps(
-            {"error": {"message": e.message, "type": "server_error", "code": "stream_error"}},
-            ensure_ascii=False,
-        )
-        yield f"data: {error_data}\n\n"
+        logger.debug("Server busy detail: %s", e.message)
+        raise
     except ClientDisconnected as e:
         logger.warning(str(e))
         # Client is gone — there's no point yielding more SSE chunks. Stop quietly.

--- a/lightllm/server/api_openai.py
+++ b/lightllm/server/api_openai.py
@@ -30,7 +30,7 @@ from .httpserver.manager import HttpServerManager
 from .httpserver_for_pd_master.manager import HttpServerManagerForPDMaster
 from .api_lightllm import lightllm_get_score
 from lightllm.utils.envs_utils import get_env_start_args, get_lightllm_websocket_max_message_size
-from lightllm.utils.error_utils import ClientDisconnected, ServerBusyError
+from lightllm.utils.error_utils import ClientDisconnected, InvalidRequestError, ServerBusyError
 
 from lightllm.utils.log_utils import init_logger
 from lightllm.server.metrics.manager import MetricClient
@@ -70,6 +70,11 @@ async def _safe_stream_wrapper(stream_generator):
         async for item in stream_generator:
             first_chunk_sent = True
             yield item
+    except InvalidRequestError as e:
+        if not first_chunk_sent:
+            raise
+        error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
+        yield f"data: {error_data}\n\n"
     except ValueError as e:
         error_data = json.dumps({"error": {"message": str(e), "type": "invalid_request_error"}}, ensure_ascii=False)
         yield f"data: {error_data}\n\n"

--- a/lightllm/server/api_stream_obj.py
+++ b/lightllm/server/api_stream_obj.py
@@ -1,34 +1,24 @@
-"""Custom streaming response behavior for PD-master request admission.
+"""Streaming response behavior for errors raised before the first chunk.
 
 Starlette's ``StreamingResponse`` sends ``http.response.start`` before it
 starts iterating over the response body. This is normally desirable because
 the client receives the HTTP status and headers immediately. However, the
-generation body used by LightLLM is an async generator, so its code does not
-run when the ``StreamingResponse`` object is created. In PD-master mode, node
-selection and admission waiting happen only when that generator is iterated.
-Consequently, a ``ServerBusyError`` may be raised during the first iteration,
-after Starlette has already sent HTTP 200.
+generation body used by LightLLM is an async generator, so request validation
+and PD-master admission do not run until the generator is iterated. An error
+raised during that first iteration would otherwise arrive after HTTP 200.
 
 An HTTP status cannot be changed after ``http.response.start`` has been sent.
-This module therefore delays that event in PD-master mode until the body has
-produced its first chunk. If admission fails before then, no response has
-started and FastAPI's exception handler can still return HTTP 429. Once the
-first chunk exists, the request has passed this initial admission point and
-the response starts normally.
-
-Only PD-master mode uses the delayed behavior. Other modes retain Starlette's
-original implementation so clients and proxies receive headers immediately
-and keep their existing response-header timeout semantics.
+This module therefore delays that event until the body has produced its first
+chunk. FastAPI can then return the appropriate HTTP error if request setup
+fails before streaming starts.
 """
 
 from fastapi.responses import StreamingResponse
 from starlette.types import Send
 
-from lightllm.utils.envs_utils import get_env_start_args
-
 
 class CustomStreamingResponse(StreamingResponse):
-    """Send the PD-master HTTP status only after the first body chunk is ready.
+    """Send the HTTP status only after the first body chunk is ready.
 
     The first chunk is sent directly after the response headers; it is not
     discarded or replayed through another iterator. Empty streams still send
@@ -41,13 +31,6 @@ class CustomStreamingResponse(StreamingResponse):
     """
 
     async def stream_response(self, send: Send) -> None:
-        # Preserve Starlette's immediate response-start behavior outside
-        # PD-master mode. Delaying every streaming response would make normal
-        # first-token latency count against response-header timeouts.
-        if get_env_start_args().run_mode != "pd_master":
-            await super().stream_response(send)
-            return
-
         async def send_chunk(chunk):
             if not isinstance(chunk, (bytes, memoryview)):
                 chunk = chunk.encode(self.charset)
@@ -65,8 +48,8 @@ class CustomStreamingResponse(StreamingResponse):
             )
 
         # Iterating here starts the otherwise-lazy generation pipeline. A
-        # ServerBusyError raised before the first yield escapes without an
-        # http.response.start event, allowing FastAPI to produce HTTP 429.
+        # An error raised before the first yield escapes without an
+        # http.response.start event, allowing FastAPI to handle it.
         async for first_chunk in self.body_iterator:
             await send_response_start()
             await send_chunk(first_chunk)

--- a/lightllm/server/api_stream_obj.py
+++ b/lightllm/server/api_stream_obj.py
@@ -1,24 +1,34 @@
-"""Streaming response behavior for errors raised before the first chunk.
+"""Custom streaming response behavior for PD-master request admission.
 
 Starlette's ``StreamingResponse`` sends ``http.response.start`` before it
 starts iterating over the response body. This is normally desirable because
 the client receives the HTTP status and headers immediately. However, the
-generation body used by LightLLM is an async generator, so request validation
-and PD-master admission do not run until the generator is iterated. An error
-raised during that first iteration would otherwise arrive after HTTP 200.
+generation body used by LightLLM is an async generator, so its code does not
+run when the ``StreamingResponse`` object is created. In PD-master mode, node
+selection and admission waiting happen only when that generator is iterated.
+Consequently, a ``ServerBusyError`` may be raised during the first iteration,
+after Starlette has already sent HTTP 200.
 
 An HTTP status cannot be changed after ``http.response.start`` has been sent.
-This module therefore delays that event until the body has produced its first
-chunk. FastAPI can then return the appropriate HTTP error if request setup
-fails before streaming starts.
+This module therefore delays that event in PD-master mode until the body has
+produced its first chunk. If admission fails before then, no response has
+started and FastAPI's exception handler can still return HTTP 429. Once the
+first chunk exists, the request has passed this initial admission point and
+the response starts normally.
+
+Only PD-master mode uses the delayed behavior. Other modes retain Starlette's
+original implementation so clients and proxies receive headers immediately
+and keep their existing response-header timeout semantics.
 """
 
 from fastapi.responses import StreamingResponse
 from starlette.types import Send
 
+from lightllm.utils.envs_utils import get_env_start_args
+
 
 class CustomStreamingResponse(StreamingResponse):
-    """Send the HTTP status only after the first body chunk is ready.
+    """Send the PD-master HTTP status only after the first body chunk is ready.
 
     The first chunk is sent directly after the response headers; it is not
     discarded or replayed through another iterator. Empty streams still send
@@ -31,6 +41,13 @@ class CustomStreamingResponse(StreamingResponse):
     """
 
     async def stream_response(self, send: Send) -> None:
+        # Preserve Starlette's immediate response-start behavior outside
+        # PD-master mode. Delaying every streaming response would make normal
+        # first-token latency count against response-header timeouts.
+        if get_env_start_args().run_mode != "pd_master":
+            await super().stream_response(send)
+            return
+
         async def send_chunk(chunk):
             if not isinstance(chunk, (bytes, memoryview)):
                 chunk = chunk.encode(self.charset)
@@ -48,8 +65,8 @@ class CustomStreamingResponse(StreamingResponse):
             )
 
         # Iterating here starts the otherwise-lazy generation pipeline. A
-        # An error raised before the first yield escapes without an
-        # http.response.start event, allowing FastAPI to handle it.
+        # ServerBusyError raised before the first yield escapes without an
+        # http.response.start event, allowing FastAPI to produce HTTP 429.
         async for first_chunk in self.body_iterator:
             await send_response_start()
             await send_chunk(first_chunk)

--- a/lightllm/server/api_stream_obj.py
+++ b/lightllm/server/api_stream_obj.py
@@ -1,24 +1,22 @@
-"""Custom streaming response behavior for PD-master request admission.
+"""Custom streaming response behavior for errors raised before the first chunk.
 
 Starlette's ``StreamingResponse`` sends ``http.response.start`` before it
 starts iterating over the response body. This is normally desirable because
 the client receives the HTTP status and headers immediately. However, the
-generation body used by LightLLM is an async generator, so its code does not
-run when the ``StreamingResponse`` object is created. In PD-master mode, node
-selection and admission waiting happen only when that generator is iterated.
-Consequently, a ``ServerBusyError`` may be raised during the first iteration,
-after Starlette has already sent HTTP 200.
+generation body used by LightLLM is an async generator, so request validation
+and admission do not run until that generator is iterated. Consequently, an
+error may be raised during the first iteration, after Starlette has already
+sent HTTP 200.
 
 An HTTP status cannot be changed after ``http.response.start`` has been sent.
-This module therefore delays that event in PD-master mode until the body has
-produced its first chunk. If admission fails before then, no response has
-started and FastAPI's exception handler can still return HTTP 429. Once the
-first chunk exists, the request has passed this initial admission point and
-the response starts normally.
+This module therefore delays that event until the body has produced its first
+chunk. If request setup fails before then, no response has started and
+FastAPI's exception handler can still return the appropriate HTTP error. Once
+the first chunk exists, the response starts normally.
 
-Only PD-master mode uses the delayed behavior. Other modes retain Starlette's
-original implementation so clients and proxies receive headers immediately
-and keep their existing response-header timeout semantics.
+The ``--disable_delay_response_start`` startup option restores Starlette's
+original behavior for clients and proxies that require response status and
+headers immediately.
 """
 
 from fastapi.responses import StreamingResponse
@@ -28,7 +26,7 @@ from lightllm.utils.envs_utils import get_env_start_args
 
 
 class CustomStreamingResponse(StreamingResponse):
-    """Send the PD-master HTTP status only after the first body chunk is ready.
+    """Send the HTTP status only after the first body chunk is ready.
 
     The first chunk is sent directly after the response headers; it is not
     discarded or replayed through another iterator. Empty streams still send
@@ -41,10 +39,9 @@ class CustomStreamingResponse(StreamingResponse):
     """
 
     async def stream_response(self, send: Send) -> None:
-        # Preserve Starlette's immediate response-start behavior outside
-        # PD-master mode. Delaying every streaming response would make normal
-        # first-token latency count against response-header timeouts.
-        if get_env_start_args().run_mode != "pd_master":
+        # Some clients and proxies require headers before first-token work is
+        # complete. Let deployments opt out of the delayed response start.
+        if get_env_start_args().disable_delay_response_start:
             await super().stream_response(send)
             return
 
@@ -65,8 +62,8 @@ class CustomStreamingResponse(StreamingResponse):
             )
 
         # Iterating here starts the otherwise-lazy generation pipeline. A
-        # ServerBusyError raised before the first yield escapes without an
-        # http.response.start event, allowing FastAPI to produce HTTP 429.
+        # An error raised before the first yield escapes without an
+        # http.response.start event, allowing FastAPI to handle it.
         async for first_chunk in self.body_iterator:
             await send_response_start()
             await send_chunk(first_chunk)

--- a/lightllm/server/core/objs/start_args_type.py
+++ b/lightllm/server/core/objs/start_args_type.py
@@ -14,6 +14,7 @@ class StartArgs:
     host: str = field(default="127.0.0.1")
     port: int = field(default=8000)
     httpserver_workers: int = field(default=1)
+    disable_delay_response_start: bool = field(default=False)
     hypercorn_config: Optional[str] = field(default=None)
     zmq_mode: str = field(
         default="ipc:///tmp/",

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -42,7 +42,12 @@ from lightllm.utils.envs_utils import (
     get_unique_server_name,
 )
 from lightllm.utils.shm_port_args import get_shm_port_args
-from lightllm.utils.error_utils import ClientDisconnected, PDPrefillNodeStopGenToken, ServerBusyError
+from lightllm.utils.error_utils import (
+    ClientDisconnected,
+    InvalidRequestError,
+    PDPrefillNodeStopGenToken,
+    ServerBusyError,
+)
 from rpyc.utils.classic import obtain
 
 logger = init_logger(__name__)
@@ -614,15 +619,6 @@ class HttpServerManager(HttpRlManagerHelper, object):
         self, prompt: Union[str, List[int]], multimodal_params: MultimodalParams, sampling_params: SamplingParams
     ):
         if isinstance(prompt, str):
-            # pre-verify prompt length
-            # The average character length per token is always less than 8
-            # TODO: automatically calculate the average character length per token
-            max_prompt_chars = self.max_req_total_len * 8
-            if len(prompt) > max_prompt_chars:
-                raise ValueError(
-                    f"prompt text length {len(prompt)} exceeds the character limit {max_prompt_chars}, "
-                    f"the request is rejected before tokenization."
-                )
             if self.enable_multimodal:
                 multimodal_params.verify_resource_limits()
                 await self._alloc_multimodal_resources(multimodal_params, sampling_params)
@@ -678,7 +674,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
 
     async def _check_and_repair_length(self, prompt_ids: List[int], sampling_params: SamplingParams):
         if not prompt_ids:
-            raise ValueError("prompt_ids is empty")
+            raise InvalidRequestError("The input prompt must not be empty.")
         prompt_tokens = len(prompt_ids)
         # 这里 -36 是保留一些不可预知的边界余量，防止系统出错
         real_supported_max_req_total_len = self.get_real_supported_max_req_total_len()
@@ -695,16 +691,22 @@ class HttpServerManager(HttpRlManagerHelper, object):
                 )
                 sampling_params.max_new_tokens = new_max_new_tokens
             else:
-                raise ValueError(
-                    f"the input prompt token len {prompt_tokens} + max_new_tokens \
-                        {sampling_params.max_new_tokens} > {real_supported_max_req_total_len}"
+                raise InvalidRequestError(
+                    f"This model's maximum context length is {real_supported_max_req_total_len} tokens. "
+                    f"However, you requested {sampling_params.max_new_tokens} output tokens and your prompt "
+                    f"contains {prompt_tokens} input tokens, for a total of "
+                    f"{prompt_tokens + sampling_params.max_new_tokens} tokens. Please reduce the length of "
+                    f"the input prompt or the number of requested output tokens."
                 )
 
         # last repaired
         req_total_len = len(prompt_ids) + sampling_params.max_new_tokens
         if req_total_len > self.max_req_total_len:
-            raise ValueError(
-                f"the req total len (input len + output len) is too long > max_req_total_len:{self.max_req_total_len}"
+            raise InvalidRequestError(
+                f"This model's maximum context length is {self.max_req_total_len} tokens. "
+                f"However, you requested {sampling_params.max_new_tokens} output tokens and your prompt "
+                f"contains {prompt_tokens} input tokens, for a total of {req_total_len} tokens. "
+                f"Please reduce the length of the input prompt or the number of requested output tokens."
             )
 
         return prompt_ids

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -649,7 +649,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
                 if all(e < self.vocab_size for e in prompt):
                     return prompt
                 else:
-                    raise ValueError("prompt List[int] format contain id > vocab_size")
+                    raise InvalidRequestError("prompt List[int] format contain id > vocab_size")
             else:
                 if self.enable_multimodal and self.pd_mode.is_P_or_NORMAL():
                     multimodal_params.verify_resource_limits()
@@ -665,7 +665,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
                     )
                 return prompt
         else:
-            raise ValueError(f"prompt format error, get type{type(prompt)}")
+            raise InvalidRequestError(f"prompt format error, get type{type(prompt)}")
         return
 
     def get_real_supported_max_req_total_len(self):

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -649,7 +649,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
                 if all(e < self.vocab_size for e in prompt):
                     return prompt
                 else:
-                    raise InvalidRequestError("prompt List[int] format contain id > vocab_size")
+                    raise InvalidRequestError("The input contains token IDs outside the model vocabulary.")
             else:
                 if self.enable_multimodal and self.pd_mode.is_P_or_NORMAL():
                     multimodal_params.verify_resource_limits()
@@ -665,7 +665,7 @@ class HttpServerManager(HttpRlManagerHelper, object):
                     )
                 return prompt
         else:
-            raise InvalidRequestError(f"prompt format error, get type{type(prompt)}")
+            raise InvalidRequestError("The input prompt must be a string or a list of token IDs.")
         return
 
     def get_real_supported_max_req_total_len(self):

--- a/lightllm/server/httpserver/manager.py
+++ b/lightllm/server/httpserver/manager.py
@@ -619,6 +619,16 @@ class HttpServerManager(HttpRlManagerHelper, object):
         self, prompt: Union[str, List[int]], multimodal_params: MultimodalParams, sampling_params: SamplingParams
     ):
         if isinstance(prompt, str):
+            # pre-verify prompt length
+            # The average character length per token is always less than 8
+            # TODO: automatically calculate the average character length per token
+            max_prompt_chars = self.max_req_total_len * 8
+            if len(prompt) > max_prompt_chars:
+                raise InvalidRequestError(
+                    f"prompt text length {len(prompt)} exceeds the character limit {max_prompt_chars}, "
+                    f"the request is rejected before tokenization."
+                )
+
             if self.enable_multimodal:
                 multimodal_params.verify_resource_limits()
                 await self._alloc_multimodal_resources(multimodal_params, sampling_params)

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 logger = init_logger(__name__)
 
+SERVER_BUSY_MESSAGE = "Server is busy, please try again later"
+
 
 class InvalidRequestError(ValueError):
     """Request validation failed before generation started."""
@@ -11,7 +13,7 @@ class InvalidRequestError(ValueError):
 class ServerBusyError(Exception):
     """Custom exception for server busy/overload situations"""
 
-    def __init__(self, message="Server is busy, please try again later", status_code=429):
+    def __init__(self, message=SERVER_BUSY_MESSAGE, status_code=429):
         """
         Initialize the ServerBusyError
 

--- a/lightllm/utils/error_utils.py
+++ b/lightllm/utils/error_utils.py
@@ -4,6 +4,10 @@ from typing import Optional
 logger = init_logger(__name__)
 
 
+class InvalidRequestError(ValueError):
+    """Request validation failed before generation started."""
+
+
 class ServerBusyError(Exception):
     """Custom exception for server busy/overload situations"""
 

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -236,18 +236,44 @@ def test_safe_stream_terminates_invalid_error_after_first_chunk(error_type):
     assert chunks[2] == "data: [DONE]\n\n"
 
 
-def test_safe_stream_propagates_value_error_before_first_chunk():
+def test_safe_stream_converts_value_error_before_first_chunk():
     async def run():
         async def generate():
             if False:
                 yield
             raise ValueError("prompt is too long")
 
-        with pytest.raises(ValueError, match="prompt is too long"):
+        with pytest.raises(InvalidRequestError, match="prompt is too long"):
             async for _ in api_openai._safe_stream_wrapper(generate()):
                 pass
 
     asyncio.run(run())
+
+
+def test_stream_returns_http_400_for_value_error_before_first_chunk(monkeypatch):
+    metric_client = _MetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+    app = FastAPI()
+    app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
+
+    @app.get("/")
+    async def generate_stream():
+        async def generate():
+            if False:
+                yield
+            raise ValueError("invalid token id")
+
+        return CustomStreamingResponse(api_openai._safe_stream_wrapper(generate()))
+
+    async def run():
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/")
+
+    response = asyncio.run(run())
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "invalid token id"
+    assert metric_client.counters == ["lightllm_request_failure"]
 
 
 def test_safe_stream_propagates_busy_error_before_first_chunk():

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -197,6 +197,7 @@ def test_safe_stream_reports_busy_error_after_first_chunk():
     error = json.loads(chunks[1].removeprefix("data: "))
 
     assert chunks[0] == "first"
+    assert chunks[2] == "data: [DONE]\n\n"
     assert error["error"] == {
         "message": "Server is busy, please try again later",
         "type": "server_error",

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -7,9 +7,9 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from lightllm.server import api_anthropic, api_errors, api_http, api_openai, api_stream_obj
+from lightllm.server import api_anthropic, api_errors, api_http, api_openai
 from lightllm.server.api_stream_obj import CustomStreamingResponse
-from lightllm.utils.error_utils import ServerBusyError
+from lightllm.utils.error_utils import InvalidRequestError, ServerBusyError
 
 
 class _MetricClient:
@@ -51,9 +51,7 @@ def test_anthropic_error_type(error, expected):
     assert api_anthropic._anthropic_error_type(error) == expected
 
 
-def test_pd_master_stream_starts_response_after_first_chunk(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
-
+def test_stream_starts_response_after_first_chunk():
     async def run():
         response = None
 
@@ -82,21 +80,19 @@ def test_pd_master_stream_starts_response_after_first_chunk(monkeypatch):
     assert messages[0]["status"] == 201
 
 
-def test_pd_master_stream_propagates_busy_error_before_response_start(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
-
+def test_stream_propagates_error_before_response_start():
     async def run():
         async def generate():
             if False:
                 yield
-            raise ServerBusyError()
+            raise InvalidRequestError("prompt is too long")
 
         messages = []
 
         async def send(message):
             messages.append(message)
 
-        with pytest.raises(ServerBusyError):
+        with pytest.raises(InvalidRequestError, match="prompt is too long"):
             await CustomStreamingResponse(generate()).stream_response(send)
 
         return messages
@@ -104,8 +100,7 @@ def test_pd_master_stream_propagates_busy_error_before_response_start(monkeypatc
     assert asyncio.run(run()) == []
 
 
-def test_pd_master_stream_can_return_http_429(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+def test_stream_can_return_http_429():
     app = FastAPI()
 
     @app.exception_handler(ServerBusyError)
@@ -131,11 +126,36 @@ def test_pd_master_stream_can_return_http_429(monkeypatch):
     assert response.json() == {"error": "server busy"}
 
 
+def test_stream_can_return_http_400_for_invalid_request(monkeypatch):
+    metric_client = _MetricClient()
+    monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+    app = FastAPI()
+    app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
+
+    @app.get("/")
+    async def generate_stream():
+        async def generate():
+            if False:
+                yield
+            raise InvalidRequestError("prompt is too long")
+
+        return CustomStreamingResponse(api_openai._safe_stream_wrapper(generate()))
+
+    async def run():
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/")
+
+    response = asyncio.run(run())
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "prompt is too long"
+    assert metric_client.counters == ["lightllm_request_failure"]
+
+
 def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
     monkeypatch.setattr(api_http, "get_env_start_args", lambda: SimpleNamespace(run_mode="normal"))
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
 
     async def anthropic_messages_impl(_request):
         async def generate():
@@ -178,6 +198,20 @@ def test_safe_stream_reports_busy_error_after_first_chunk():
     assert chunks[0] == "first"
     assert error["error"]["type"] == "server_error"
     assert error["error"]["code"] == "stream_error"
+
+
+def test_safe_stream_propagates_invalid_request_before_first_chunk():
+    async def run():
+        async def generate():
+            if False:
+                yield
+            raise InvalidRequestError("prompt is too long")
+
+        with pytest.raises(InvalidRequestError, match="prompt is too long"):
+            async for _ in api_openai._safe_stream_wrapper(generate()):
+                pass
+
+    asyncio.run(run())
 
 
 def test_safe_stream_propagates_busy_error_before_first_chunk():

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -35,6 +35,7 @@ def test_server_busy_response_is_rate_limited(monkeypatch):
     assert response.status_code == 429
     assert body["error"]["type"] == "RateLimitError"
     assert body["error"]["code"] == 429
+    assert body["error"]["message"] == "Server is busy, please try again later"
     assert metric_client.counters == ["lightllm_request_failure"]
 
 
@@ -178,26 +179,26 @@ def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
         "type": "error",
         "error": {
             "type": "rate_limit_error",
-            "message": "Server is busy, please try again later (Status code: 429)",
+            "message": "Server is busy, please try again later",
         },
     }
     assert metric_client.counters == ["lightllm_request_failure"]
 
 
-def test_safe_stream_reports_busy_error_after_first_chunk():
+def test_safe_stream_propagates_busy_error_after_first_chunk():
     async def run():
         async def generate():
             yield "first"
             raise ServerBusyError()
 
-        return [item async for item in api_openai._safe_stream_wrapper(generate())]
+        chunks = []
+        with pytest.raises(ServerBusyError):
+            async for item in api_openai._safe_stream_wrapper(generate()):
+                chunks.append(item)
+        return chunks
 
     chunks = asyncio.run(run())
-    error = json.loads(chunks[1].removeprefix("data: "))
-
-    assert chunks[0] == "first"
-    assert error["error"]["type"] == "server_error"
-    assert error["error"]["code"] == "stream_error"
+    assert chunks == ["first"]
 
 
 def test_safe_stream_propagates_invalid_request_before_first_chunk():

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -8,7 +8,9 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from lightllm.server import api_anthropic, api_errors, api_http, api_openai, api_stream_obj
+from lightllm.server.api_cli import make_argument_parser
 from lightllm.server.api_stream_obj import CustomStreamingResponse
+from lightllm.server.core.objs.start_args_type import StartArgs
 from lightllm.utils.error_utils import InvalidRequestError, ServerBusyError
 
 
@@ -18,6 +20,14 @@ class _MetricClient:
 
     def counter_inc(self, name):
         self.counters.append(name)
+
+
+def test_delay_response_start_cli_defaults_to_enabled_and_can_be_disabled():
+    parser = make_argument_parser()
+
+    assert parser.parse_args([]).disable_delay_response_start is False
+    assert parser.parse_args(["--disable_delay_response_start"]).disable_delay_response_start is True
+    assert StartArgs().disable_delay_response_start is False
 
 
 def test_api_modules_share_error_response_factory():
@@ -52,8 +62,12 @@ def test_anthropic_error_type(error, expected):
     assert api_anthropic._anthropic_error_type(error) == expected
 
 
-def test_pd_master_stream_starts_response_after_first_chunk(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+def test_stream_starts_response_after_first_chunk_by_default(monkeypatch):
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
 
     async def run():
         response = None
@@ -83,8 +97,41 @@ def test_pd_master_stream_starts_response_after_first_chunk(monkeypatch):
     assert messages[0]["status"] == 201
 
 
-def test_pd_master_stream_propagates_error_before_response_start(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+def test_disable_delay_response_start_sends_status_immediately(monkeypatch):
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=True),
+    )
+
+    async def run():
+        response = None
+
+        async def generate():
+            response.status_code = 201
+            yield "first"
+
+        messages = []
+
+        async def send(message):
+            messages.append(message)
+
+        response = CustomStreamingResponse(generate())
+        await response.stream_response(send)
+        return messages
+
+    messages = asyncio.run(run())
+    assert messages[0]["type"] == "http.response.start"
+    assert messages[0]["status"] == 200
+    assert messages[1]["body"] == b"first"
+
+
+def test_stream_propagates_error_before_response_start(monkeypatch):
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
 
     async def run():
         async def generate():
@@ -105,8 +152,12 @@ def test_pd_master_stream_propagates_error_before_response_start(monkeypatch):
     assert asyncio.run(run()) == []
 
 
-def test_pd_master_stream_can_return_http_429(monkeypatch):
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+def test_delayed_stream_can_return_http_429(monkeypatch):
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
 
     app = FastAPI()
 
@@ -133,10 +184,14 @@ def test_pd_master_stream_can_return_http_429(monkeypatch):
     assert response.json() == {"error": "server busy"}
 
 
-def test_pd_master_stream_can_return_http_400_for_invalid_request(monkeypatch):
+def test_delayed_stream_can_return_http_400_for_invalid_request(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
     app = FastAPI()
     app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
 
@@ -164,7 +219,11 @@ def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
     monkeypatch.setattr(api_http, "get_env_start_args", lambda: SimpleNamespace(run_mode="normal"))
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
 
     async def anthropic_messages_impl(_request):
         async def generate():
@@ -258,10 +317,14 @@ def test_safe_stream_converts_value_error_before_first_chunk():
     asyncio.run(run())
 
 
-def test_pd_master_stream_returns_http_400_for_value_error_before_first_chunk(monkeypatch):
+def test_delayed_stream_returns_http_400_for_value_error_before_first_chunk(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
-    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+    monkeypatch.setattr(
+        api_stream_obj,
+        "get_env_start_args",
+        lambda: SimpleNamespace(disable_delay_response_start=False),
+    )
     app = FastAPI()
     app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
 

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from lightllm.server import api_anthropic, api_errors, api_http, api_openai
+from lightllm.server import api_anthropic, api_errors, api_http, api_openai, api_stream_obj
 from lightllm.server.api_stream_obj import CustomStreamingResponse
 from lightllm.utils.error_utils import InvalidRequestError, ServerBusyError
 
@@ -52,7 +52,9 @@ def test_anthropic_error_type(error, expected):
     assert api_anthropic._anthropic_error_type(error) == expected
 
 
-def test_stream_starts_response_after_first_chunk():
+def test_pd_master_stream_starts_response_after_first_chunk(monkeypatch):
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+
     async def run():
         response = None
 
@@ -81,7 +83,9 @@ def test_stream_starts_response_after_first_chunk():
     assert messages[0]["status"] == 201
 
 
-def test_stream_propagates_error_before_response_start():
+def test_pd_master_stream_propagates_error_before_response_start(monkeypatch):
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+
     async def run():
         async def generate():
             if False:
@@ -101,7 +105,9 @@ def test_stream_propagates_error_before_response_start():
     assert asyncio.run(run()) == []
 
 
-def test_stream_can_return_http_429():
+def test_pd_master_stream_can_return_http_429(monkeypatch):
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
+
     app = FastAPI()
 
     @app.exception_handler(ServerBusyError)
@@ -127,9 +133,10 @@ def test_stream_can_return_http_429():
     assert response.json() == {"error": "server busy"}
 
 
-def test_stream_can_return_http_400_for_invalid_request(monkeypatch):
+def test_pd_master_stream_can_return_http_400_for_invalid_request(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
     app = FastAPI()
     app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
 
@@ -157,6 +164,7 @@ def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
     monkeypatch.setattr(api_http, "get_env_start_args", lambda: SimpleNamespace(run_mode="normal"))
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
 
     async def anthropic_messages_impl(_request):
         async def generate():
@@ -250,9 +258,10 @@ def test_safe_stream_converts_value_error_before_first_chunk():
     asyncio.run(run())
 
 
-def test_stream_returns_http_400_for_value_error_before_first_chunk(monkeypatch):
+def test_pd_master_stream_returns_http_400_for_value_error_before_first_chunk(monkeypatch):
     metric_client = _MetricClient()
     monkeypatch.setattr(api_http.g_objs, "metric_client", metric_client)
+    monkeypatch.setattr(api_stream_obj, "get_env_start_args", lambda: SimpleNamespace(run_mode="pd_master"))
     app = FastAPI()
     app.exception_handler(InvalidRequestError)(api_http.invalid_request_exception_handler)
 

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -219,6 +219,37 @@ def test_safe_stream_propagates_invalid_request_before_first_chunk():
     asyncio.run(run())
 
 
+@pytest.mark.parametrize("error_type", [InvalidRequestError, ValueError])
+def test_safe_stream_terminates_invalid_error_after_first_chunk(error_type):
+    async def run():
+        async def generate():
+            yield "first"
+            raise error_type("prompt is too long")
+
+        return [item async for item in api_openai._safe_stream_wrapper(generate())]
+
+    chunks = asyncio.run(run())
+    error = json.loads(chunks[1].removeprefix("data: "))
+
+    assert chunks[0] == "first"
+    assert error["error"] == {"message": "prompt is too long", "type": "invalid_request_error"}
+    assert chunks[2] == "data: [DONE]\n\n"
+
+
+def test_safe_stream_propagates_value_error_before_first_chunk():
+    async def run():
+        async def generate():
+            if False:
+                yield
+            raise ValueError("prompt is too long")
+
+        with pytest.raises(ValueError, match="prompt is too long"):
+            async for _ in api_openai._safe_stream_wrapper(generate()):
+                pass
+
+    asyncio.run(run())
+
+
 def test_safe_stream_propagates_busy_error_before_first_chunk():
     async def run():
         async def generate():

--- a/test/test_api/test_server_busy_handling.py
+++ b/test/test_api/test_server_busy_handling.py
@@ -185,20 +185,23 @@ def test_pd_master_anthropic_stream_preserves_error_envelope(monkeypatch):
     assert metric_client.counters == ["lightllm_request_failure"]
 
 
-def test_safe_stream_propagates_busy_error_after_first_chunk():
+def test_safe_stream_reports_busy_error_after_first_chunk():
     async def run():
         async def generate():
             yield "first"
             raise ServerBusyError()
 
-        chunks = []
-        with pytest.raises(ServerBusyError):
-            async for item in api_openai._safe_stream_wrapper(generate()):
-                chunks.append(item)
-        return chunks
+        return [item async for item in api_openai._safe_stream_wrapper(generate())]
 
     chunks = asyncio.run(run())
-    assert chunks == ["first"]
+    error = json.loads(chunks[1].removeprefix("data: "))
+
+    assert chunks[0] == "first"
+    assert error["error"] == {
+        "message": "Server is busy, please try again later",
+        "type": "server_error",
+        "code": "stream_error",
+    }
 
 
 def test_safe_stream_propagates_invalid_request_before_first_chunk():


### PR DESCRIPTION
## Summary

- validate normal-mode generation requests before streaming response headers are sent
- return HTTP 400 JSON for prompt-length errors instead of HTTP 200 SSE error chunks
- preserve SSE error reporting when a validation error happens after the stream has started
- support the same pre-stream HTTP 400 behavior in PD-master mode and preserve Anthropic error envelopes
- keep the existing lazy `generate()` API while adding an eager HTTP preflight path

## Motivation

Prompt length validation currently runs inside the async generation iterator. For streaming requests, the endpoint has already returned a `200 text/event-stream` response by the time validation fails, so `_safe_stream_wrapper` serializes the error into the SSE body. Clients consequently report a generic SSE error even though this is a deterministic invalid request.

This change runs tokenization and length validation eagerly for HTTP handlers, then suspends generation at an internal ready marker before request allocation/model execution. This allows invalid requests to return a normal 400 response without delaying valid response headers until the first generated token.

## Tests

- `PYTHONPATH=. pytest -q unit_tests/server/httpserver unit_tests/server/test_pd_master_mode.py test/test_api/test_server_busy_handling.py` (75 passed)
- `PYTHONPATH=. pytest -q unit_tests/server/core/objs/test_sampling_params.py test/test_api/test_seed_validation.py` (20 passed)
- Black check on all changed files
- Flake8 on all changed files
- `git diff --check`