### PR TITLE
fix(prompt): pass string content for text-only image requests

### DIFF
--- a/lightllm/server/build_prompt.py
+++ b/lightllm/server/build_prompt.py
@@ -106,13 +106,17 @@ async def build_prompt(request, tools) -> str:
 
 async def build_prompt_from_image_request(request: Union[ImageGenerationRequest, ImageEditRequest]) -> str:
     try:
-        user_content = []
-        if isinstance(request, ImageEditRequest):
-            [
-                user_content.append({"type": "image_url", "image_url": {"url": image.image_url[:100]}})
-                for image in request.images
+        images = request.images if isinstance(request, ImageEditRequest) else []
+        if images:
+            user_content = [
+                {"type": "image_url", "image_url": {"url": image.image_url[:100]}} for image in images
             ]
-        user_content.append({"type": "text", "text": request.prompt})
+            user_content.append({"type": "text", "text": request.prompt})
+        else:
+            # Text-only requests must pass a plain string: chat templates derived from Qwen call
+            # .startswith() on message.content, which fails on the list form with
+            # "'list object' has no attribute 'startswith'".
+            user_content = request.prompt
         kwargs = {"conversation": [{"role": "user", "content": user_content}]}
         # logger.info(f"kwargs: {kwargs}")
 


### PR DESCRIPTION


## Problem

`build_prompt_from_image_request()` always wraps the prompt in the list form of multimodal content, even when the request carries no images. Chat templates derived from Qwen call `.startswith()` directly on `message.content`, which a list does not have, so every plain text-to-image request through `/v1/images/generations` returns HTTP 417.

Reproducible offline against the model's own tokenizer: `apply_chat_template()` with `content=[{"type": "text", "text": "a red apple"}]` raises `jinja2.exceptions.UndefinedError: 'list object' has no attribute 'startswith'`, while `content="a red apple"` returns the expected `<|im_start|>user\na red apple<|im_end|>...`.

## Fix

Use the list form only when the request actually carries images; otherwise pass the prompt as a plain string, which is what the OpenAI-compatible schema allows and what these templates expect.

The guard changes from `isinstance(request, ImageEditRequest)` to whether `images` is non-empty, so an `ImageEditRequest` carrying no images now also works. The list comprehension previously used as a statement is now a normal one, a consequence of the restructuring rather than an unrelated change.


## Validation

With this change `/v1/images/generations` serves text-to-image end to end against SenseNova-U1.5-8B-MoT at 1024x1024 on AMD gfx1201/gfx1100; without it every such request returns HTTP 417. The defect is in prompt construction, with no GPU involvement.
