### PR TITLE
fix: guard thinker_config text_config lookup in _get_config_llm_keyvalue

### DIFF
--- a/lightllm/utils/config_utils.py
+++ b/lightllm/utils/config_utils.py
@@ -195,8 +195,11 @@ def _get_config_llm_keyvalue(model_path: str, key_name: list[str]):
                 value = config_json["llm_config"][key]
             except:
                 value = config_json.get("text_config", {}).get(key)
-        if config_json.get("thinker_config") is not None:
-            value = config_json.get("thinker_config", {}).get("text_config").get(key)
+        thinker_config = config_json.get("thinker_config")
+        if isinstance(thinker_config, dict):
+            thinker_text_config = thinker_config.get("text_config")
+            if isinstance(thinker_text_config, dict):
+                value = thinker_text_config.get(key, value)
         if value is not None:
             return value
 

--- a/unit_tests/utils/test_config_utils.py
+++ b/unit_tests/utils/test_config_utils.py
@@ -1,0 +1,53 @@
+import pytest
+
+from lightllm.utils import config_utils
+
+
+@pytest.fixture
+def fake_config(monkeypatch):
+    def install(cfg_json):
+        monkeypatch.setattr(config_utils, "get_config_json", lambda model_path: cfg_json)
+        return "dummy/model/dir"
+
+    return install
+
+
+def test_get_keyvalue_reads_top_level_key(fake_config):
+    model_path = fake_config({"model_type": "llama", "hidden_size": 4096})
+
+    assert config_utils._get_config_llm_keyvalue(model_path, ["hidden_size"]) == 4096
+
+
+def test_get_keyvalue_does_not_crash_when_thinker_config_lacks_text_config(fake_config):
+    cfg = {"model_type": "qwen3_omni_moe", "hidden_size": 4096, "thinker_config": {"model_type": "text"}}
+    model_path = fake_config(cfg)
+
+    assert config_utils._get_config_llm_keyvalue(model_path, ["hidden_size"]) == 4096
+
+
+def test_get_keyvalue_keeps_top_level_value_when_thinker_text_config_lacks_key(fake_config):
+    cfg = {
+        "model_type": "qwen3_omni_moe",
+        "hidden_size": 4096,
+        "thinker_config": {"text_config": {"model_type": "text"}},
+    }
+    model_path = fake_config(cfg)
+
+    assert config_utils._get_config_llm_keyvalue(model_path, ["hidden_size"]) == 4096
+
+
+def test_get_keyvalue_prefers_thinker_text_config_value_when_present(fake_config):
+    cfg = {
+        "model_type": "qwen3_omni_moe",
+        "hidden_size": 4096,
+        "thinker_config": {"text_config": {"hidden_size": 2048}},
+    }
+    model_path = fake_config(cfg)
+
+    assert config_utils._get_config_llm_keyvalue(model_path, ["hidden_size"]) == 2048
+
+
+def test_get_keyvalue_returns_none_when_key_missing_everywhere(fake_config):
+    model_path = fake_config({"model_type": "llama", "hidden_size": 4096})
+
+    assert config_utils._get_config_llm_keyvalue(model_path, ["head_dim"]) is None


### PR DESCRIPTION
Fixes #1546

## Summary
`_get_config_llm_keyvalue` in `lightllm/utils/config_utils.py` called `config_json.get("thinker_config", {}).get("text_config").get(key)` whenever `thinker_config` was present. This crashed config parsing for Qwen3-Omni-style configs whose `thinker_config` has no nested `text_config`, and silently clobbered valid top-level values with `None` when `text_config` lacked the requested key.

## Changes
- Guard both `thinker_config` and `text_config` with `isinstance` checks.
- Keep the previously resolved value via `thinker_text_config.get(key, value)` when the key is absent from `text_config`, preserving the intended preference for the nested multimodal value when it does exist.

## Tests
Added `unit_tests/utils/test_config_utils.py` with 5 regression tests (no GPU required):

- reads top-level key
- does not crash when `thinker_config` lacks `text_config`
- keeps top-level value when `text_config` lacks the key
- prefers `thinker_config.text_config` value when present
- returns `None` when key missing everywhere

Verified: `pytest unit_tests/utils/test_config_utils.py` -> `5 passed`; black and flake8 (repo config) clean.