### PR TITLE
fix(server): stop bare excepts from swallowing cancellation and shutdown

### DIFF
--- a/lightllm/server/build_prompt.py
+++ b/lightllm/server/build_prompt.py
@@ -58,7 +58,7 @@ def tokenizer_supports_force_thinking() -> bool:
         logger.debug(f"chat_template: {tokenizer.chat_template}")
         logger.info(f"tokenizer_supports_force_thinking : {ans}")
         return ans
-    except:
+    except (AttributeError, TypeError):
         pass
 
     try:
@@ -66,7 +66,7 @@ def tokenizer_supports_force_thinking() -> bool:
         logger.debug(f"tokenizer.tokenizer.chat_template: {tokenizer.tokenizer.chat_template}")
         logger.info(f"tokenizer_supports_force_thinking : {ans}")
         return ans
-    except:
+    except (AttributeError, TypeError):
         pass
 
     logger.info("tokenizer_supports_force_thinking : False")

--- a/lightllm/server/core/objs/py_sampling_params.py
+++ b/lightllm/server/core/objs/py_sampling_params.py
@@ -125,7 +125,7 @@ class SamplingParams:
             cls._top_p = _cfg("top_p", 1.0)
             cls._top_k = _cfg("top_k", -1)
             cls._stop_sequences = generation_cfg.get("stop", None)
-        except:
+        except Exception:
             pass
 
     def verify(self):

--- a/lightllm/server/core/objs/sampling_params.py
+++ b/lightllm/server/core/objs/sampling_params.py
@@ -415,7 +415,7 @@ class SamplingParams(ctypes.Structure):
             cls._temperature = _cfg("temperature", 1.0)
             cls._top_p = _cfg("top_p", 1.0)
             cls._top_k = _cfg("top_k", -1)
-        except:
+        except Exception:
             pass
 
     def verify(self):

--- a/lightllm/server/embed_cache/afs_utils.py
+++ b/lightllm/server/embed_cache/afs_utils.py
@@ -50,7 +50,7 @@ class AfsUtils:
         finally:
             try:
                 tmp_path.unlink(missing_ok=True)
-            except:
+            except OSError:
                 pass
 
     def load_tensor_afs(self, name: str) -> Optional[torch.Tensor]:
@@ -132,7 +132,7 @@ class SepEmbedHandler:
             ans = self.afs_utils.save_tensor_afs(md5, tensor)
             self.redis_client.update(md5)
             return ans
-        except:
+        except Exception:
             return False
 
     def load(self, md5: str) -> Optional[torch.Tensor]:

--- a/lightllm/server/httpserver_for_pd_master/manager.py
+++ b/lightllm/server/httpserver_for_pd_master/manager.py
@@ -103,7 +103,7 @@ class HttpServerManagerForPDMaster:
             up_status_event = self.req_id_to_out_inf[group_request_id].up_status_event
             up_status_event.upkv_status = upkv_status
             up_status_event.set()
-        except:
+        except Exception:
             pass
         return
 
@@ -414,7 +414,7 @@ class HttpServerManagerForPDMaster:
 
             try:
                 await self.abort(block_group_request_id, p_node=p_node, d_node=d_node)
-            except:
+            except Exception:
                 await self.abort(block_group_request_id)
             raise e
 
@@ -724,17 +724,17 @@ class HttpServerManagerForPDMaster:
             del self.req_id_to_out_inf[group_request_id]
             p_node = req_status.p_node
             d_node = req_status.d_node
-        except:
+        except Exception:
             pass
 
         try:
             await p_node.websocket.send_bytes(pickle.dumps((ObjType.ABORT, group_request_id)))
-        except:
+        except Exception:
             pass
 
         try:
             await d_node.websocket.send_bytes(pickle.dumps((ObjType.ABORT, group_request_id)))
-        except:
+        except Exception:
             pass
 
         return
@@ -742,7 +742,7 @@ class HttpServerManagerForPDMaster:
     async def remove_req(self, group_request_id):
         try:
             del self.req_id_to_out_inf[group_request_id]
-        except:
+        except Exception:
             pass
 
     async def timer_log(self):
@@ -782,7 +782,7 @@ class HttpServerManagerForPDMaster:
                                 async with req_status.lock:
                                     req_status.out_token_info_list.append((sub_req_id, text, metadata, finish_status))
                                     req_status.event.set()
-                            except:
+                            except Exception:
                                 pass
                     elif obj[0] == ObjType.PD_UPLOAD_PREFILL_PROMPT_IDS:
                         _, group_req_id, prompt_ids = obj
@@ -791,7 +791,7 @@ class HttpServerManagerForPDMaster:
                             async with req_status.lock:
                                 req_status.prefill_prompt_ids_event.prompt_ids = prompt_ids
                                 req_status.prefill_prompt_ids_event.set()
-                        except:
+                        except Exception:
                             logger.error(
                                 f"PD_UPLOAD_PREFILL_PROMPT_IDS fail find req status for group_req_id: {group_req_id}"
                             )

--- a/lightllm/server/metrics/manager.py
+++ b/lightllm/server/metrics/manager.py
@@ -70,7 +70,7 @@ class MetricServer(rpyc.Service):
                 if time_counter >= 60:
                     logger.info("push metrices success")
                     time_counter = 0
-            except:
+            except Exception:
                 pass
             finally:
                 time.sleep(self.interval)

--- a/lightllm/server/multi_level_kv_cache/shm_objs.py
+++ b/lightllm/server/multi_level_kv_cache/shm_objs.py
@@ -294,7 +294,7 @@ def _create_shm(name: str, byte_size: int):
     try:
         shm = ServiceSharedMemory(name=name, create=True, size=byte_size)
         logger.info(f"create lock shm {name}")
-    except:
+    except Exception:
         shm = ServiceSharedMemory(name=name, create=False, size=byte_size)
         logger.info(f"link lock shm {name}")
     return shm

--- a/lightllm/server/router/model_infer/mode_backend/pd/decode_node_impl/decode_trans_process.py
+++ b/lightllm/server/router/model_infer/mode_backend/pd/decode_node_impl/decode_trans_process.py
@@ -258,7 +258,7 @@ class _DecodeTransModule:
                     for notify in _notify_list:
                         try:
                             notify_obj = pickle.loads(notify)
-                        except:
+                        except Exception:
                             notify_obj = None
 
                         if not isinstance(notify_obj, PDChunckedTransTask):

--- a/lightllm/server/router/model_infer/mode_backend/pd/trans_process_obj.py
+++ b/lightllm/server/router/model_infer/mode_backend/pd/trans_process_obj.py
@@ -55,7 +55,7 @@ class KVTransProcess:
                 return False
             else:
                 return True
-        except:
+        except Exception:
             return False
 
     def killself(self):


### PR DESCRIPTION
## Summary

Replaces the 18 bare `except:` clauses in `lightllm/server/` (ruff E722). A bare except catches `BaseException`, which in an async serving stack silently swallows `asyncio.CancelledError`, `KeyboardInterrupt`, and `SystemExit` — 8 of these sites are in `httpserver_for_pd_master/manager.py`, on the PD-master request lifecycle (abort fallbacks, status updates, request-table cleanup), where an eaten cancellation can leak or hang a request instead of unwinding it.

Chosen replacements:

- **`except Exception:`** for the 15 intentional catch-and-continue sites — identical behavior for all ordinary errors, but cancellation/shutdown now propagates.
- **`except (AttributeError, TypeError):`** for the two `chat_template` capability probes in `build_prompt.py` (the only failures attribute probing produces).
- **`except OSError:`** for the temp-file `unlink` cleanup in `embed_cache/afs_utils.py`.

## Testing
`python -m py_compile` passes on all nine files; `ruff check --select E722` on `lightllm/server/` goes from 18 errors to clean. No functional change for ordinary exceptions — only `BaseException`-family propagation is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)