### PR TITLE
fix(security): replace pickle deserialization with JSON in config_server WebSocket registration (GH-1563)

### DIFF
--- a/lightllm/server/config_server/api_http.py
+++ b/lightllm/server/config_server/api_http.py
@@ -1,6 +1,7 @@
 import time
 import asyncio
 import base64
+import json
 import pickle
 import setproctitle
 import multiprocessing as mp
@@ -23,6 +24,28 @@ registered_pd_master_objs: Dict[str, PD_Master_Obj] = {}
 registered_visual_server_objs: Dict[str, VIT_Obj] = {}
 registered_pd_master_obj_lock = Lock()
 registered_visual_server_obj_lock = Lock()
+
+
+def _parse_pd_master_obj(raw: dict) -> PD_Master_Obj:
+    if not isinstance(raw, dict):
+        raise ValueError("registration payload must be a JSON object")
+    node_id = raw.get("node_id")
+    host_ip_port = raw.get("host_ip_port")
+    if not isinstance(node_id, int) or not isinstance(host_ip_port, str):
+        raise ValueError("invalid PD_Master_Obj registration payload")
+    return PD_Master_Obj(node_id=node_id, host_ip_port=host_ip_port)
+
+
+def _parse_vit_obj(raw: dict) -> VIT_Obj:
+    if not isinstance(raw, dict):
+        raise ValueError("registration payload must be a JSON object")
+    node_id = raw.get("node_id")
+    host_ip = raw.get("host_ip")
+    port = raw.get("port")
+    if not isinstance(node_id, int) or not isinstance(host_ip, str) or not isinstance(port, int):
+        raise ValueError("invalid VIT_Obj registration payload")
+    return VIT_Obj(node_id=node_id, host_ip=host_ip, port=port)
+
 
 global_req_id = 0
 global_req_id_lock = Lock()
@@ -56,7 +79,12 @@ async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     client_ip, client_port = websocket.client
     logger.info(f"ws connected from IP: {client_ip}, Port: {client_port}")
-    registered_pd_master_obj: PD_Master_Obj = pickle.loads(await websocket.receive_bytes())
+    try:
+        registered_pd_master_obj = _parse_pd_master_obj(json.loads(await websocket.receive_text()))
+    except Exception as e:  # noqa: BLE001 - reject any malformed registration input without crashing the handler
+        logger.error(f"rejected pd_master registration from {client_ip}:{client_port}: {e}")
+        await websocket.close(code=1008)
+        return
     logger.info(f"received registered_pd_master_obj {registered_pd_master_obj}")
     with registered_pd_master_obj_lock:
         registered_pd_master_objs[registered_pd_master_obj.node_id] = registered_pd_master_obj
@@ -80,7 +108,12 @@ async def visual_websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     client_ip, client_port = websocket.client
     logger.info(f"ws connected from IP: {client_ip}, Port: {client_port}")
-    registered_visual_server_obj: VIT_Obj = pickle.loads(await websocket.receive_bytes())
+    try:
+        registered_visual_server_obj = _parse_vit_obj(json.loads(await websocket.receive_text()))
+    except Exception as e:  # noqa: BLE001 - reject any malformed registration input without crashing the handler
+        logger.error(f"rejected visual_server registration from {client_ip}:{client_port}: {e}")
+        await websocket.close(code=1008)
+        return
     logger.info(f"received registered_visual_server_obj {registered_visual_server_obj}")
     with registered_visual_server_obj_lock:
         registered_visual_server_objs[registered_visual_server_obj.node_id] = registered_visual_server_obj

--- a/lightllm/server/httpserver_for_pd_master/register_loop.py
+++ b/lightllm/server/httpserver_for_pd_master/register_loop.py
@@ -1,5 +1,6 @@
 import asyncio
-import pickle
+import dataclasses
+import json
 import websockets
 import socket
 from lightllm.utils.net_utils import get_hostname_ip
@@ -33,7 +34,7 @@ async def register_loop(manager: HttpServerManagerForPDMaster):
                     node_id=manager.args.pd_node_id, host_ip_port=f"{manager.host_ip}:{ports.port}"
                 )
 
-                await websocket.send(pickle.dumps(pd_master_obj))
+                await websocket.send(json.dumps(dataclasses.asdict(pd_master_obj)))
                 logger.info(f"Sent registration pd_master obj: {pd_master_obj}")
 
                 while True:

--- a/lightllm/server/visualserver/visual_only_manager.py
+++ b/lightllm/server/visualserver/visual_only_manager.py
@@ -5,7 +5,8 @@ import inspect
 import setproctitle
 import threading
 import uuid
-import pickle
+import dataclasses
+import json
 import websockets
 import socket
 import sys
@@ -80,7 +81,7 @@ class VisualOnlyManager(rpyc.Service):
 
                     vit_obj = VIT_Obj(node_id=args.visual_node_id, host_ip=host_ip, port=ports.visual_rpyc_port)
 
-                    await websocket.send(pickle.dumps(vit_obj))
+                    await websocket.send(json.dumps(dataclasses.asdict(vit_obj)))
                     logger.info(f"Sent registration vit_obj: {vit_obj}")
 
                     while True:


### PR DESCRIPTION
Fixes #1563.

## Vulnerability

`/visual_register` and `/pd_master_register` in `lightllm/server/config_server/api_http.py` both accept an unauthenticated WebSocket connection and pass the first frame straight into `pickle.loads()`:

```python
registered_visual_server_obj: VIT_Obj = pickle.loads(await websocket.receive_bytes())
```

`pickle.loads()` on untrusted network input allows arbitrary code execution via `__reduce__` (CWE-502) — #1563 has a full PoC for `/visual_register` demonstrating file-write via `exec` in the Config Server process.

## Fix

Both registered objects (`VIT_Obj`, `PD_Master_Obj`) are plain dataclasses with only `int`/`str` fields, fully representable as JSON — no functional need for pickle here. This switches the wire format: the two legitimate client call sites (`visual_only_manager.py`, `register_loop.py`) now send `json.dumps(dataclasses.asdict(obj))` as text, and the server parses it through a small validator that checks the payload is a dict with the expected field names and types before constructing the dataclass:

```python
def _parse_vit_obj(raw: dict) -> VIT_Obj:
    if not isinstance(raw, dict):
        raise ValueError("registration payload must be a JSON object")
    node_id = raw.get("node_id")
    host_ip = raw.get("host_ip")
    port = raw.get("port")
    if not isinstance(node_id, int) or not isinstance(host_ip, str) or not isinstance(port, int):
        raise ValueError("invalid VIT_Obj registration payload")
    return VIT_Obj(node_id=node_id, host_ip=host_ip, port=port)
```

Malformed input closes the connection (code 1008) with a logged reason instead of being deserialized.

## Scope note

`/pd_master_register` has the identical vulnerable pattern in the same file and wasn't in scope of #1563 (which only reports `/visual_register`), but leaving it unpatched right next to the endpoint this PR fixes didn't seem right, so it's fixed here too rather than filed as a separate report.

`/registered_objects` and `/registered_visual_objects` still use `pickle.dumps()` to serialize server-computed registry state for their HTTP GET responses — left unchanged, since `pickle.dumps()` of trusted local data isn't the deserialization sink this issue is about.

## Verification

No local checkout — Windows NTFS rejects this repo's Triton autotune JSON filenames (`:` in path segments) even with sparse-checkout, so this was built via the Contents/Git Data API against the three affected files directly. Verified:
- All three changed files pass `python -m py_compile`.
- Manually round-tripped both dataclasses through the exact `_parse_*` validators standalone (`dataclasses.asdict` → `json.dumps` → `json.loads` → validator → equality check against the original object) — passes for both `VIT_Obj` and `PD_Master_Obj`.
- Confirmed the validators reject a non-dict payload and a dict with a wrong-typed field, both with a `ValueError` rather than constructing the dataclass.
